### PR TITLE
fix: regionをoptionalに変更しビルドエラーを解消

### DIFF
--- a/src/components/case-list/CaseCard.tsx
+++ b/src/components/case-list/CaseCard.tsx
@@ -50,9 +50,11 @@ export default function CaseCard({ caseItem }: CaseCardProps) {
 
       {/* Tags */}
       <div className="flex flex-wrap gap-1.5">
-        <span className={`text-xs font-medium px-2 py-0.5 rounded-full ${regionStyles[caseItem.region] ?? 'bg-gray-100 text-gray-600'}`}>
-          {caseItem.region}
-        </span>
+        {caseItem.region && (
+          <span className={`text-xs font-medium px-2 py-0.5 rounded-full ${regionStyles[caseItem.region] ?? 'bg-gray-100 text-gray-600'}`}>
+            {caseItem.region}
+          </span>
+        )}
         <span className={`text-xs font-medium px-2 py-0.5 rounded-full ${domainStyles[caseItem.domain] ?? 'bg-gray-100 text-gray-600'}`}>
           {caseItem.domain}
         </span>

--- a/src/hooks/useFilter.ts
+++ b/src/hooks/useFilter.ts
@@ -78,7 +78,7 @@ function collectFilterOptions(cases: Case[]): Record<string, string[]> {
   }
 
   for (const c of cases) {
-    options.region.add(c.region)
+    if (c.region) options.region.add(c.region)
     options.domain.add(c.domain)
     for (const cat of c.usecase_category) {
       options.usecase_category.add(cat)
@@ -111,7 +111,7 @@ function matchesArrayFilter(value: string, filterValues: string[]): boolean {
 function applyFilters(cases: Case[], filters: FilterState): Case[] {
   return cases.filter((c) => {
     if (!matchesQuery(c, filters.query)) return false
-    if (!matchesArrayFilter(c.region, filters.region)) return false
+    if (!matchesArrayFilter(c.region ?? '', filters.region)) return false
     if (!matchesArrayFilter(c.domain, filters.domain)) return false
     if (filters.usecase_category.length > 0 && !c.usecase_category.some(cat => filters.usecase_category.includes(cat))) return false
     return true

--- a/src/lib/summary.ts
+++ b/src/lib/summary.ts
@@ -29,7 +29,7 @@ export function countByField(
       for (const v of value) {
         counts.set(v, (counts.get(v) ?? 0) + 1)
       }
-    } else {
+    } else if (value) {
       counts.set(value, (counts.get(value) ?? 0) + 1)
     }
   }

--- a/src/types/case.ts
+++ b/src/types/case.ts
@@ -80,7 +80,7 @@ export interface Figure {
 export interface Case {
   id: string;
   title: string;
-  region: Region;
+  region?: Region;
   domain: string;
   organization: string;
   usecase_category: string[];


### PR DESCRIPTION
- Case型のregionをoptional化（フォームで任意のため）
- CaseCard: region未設定時はバッジ非表示
- useFilter/summary: undefinedのregionを安全に処理