### PR TITLE
refactor: コードレビューに基づくリファクタリング

### DIFF
--- a/src/components/case-detail/CasePreview.tsx
+++ b/src/components/case-detail/CasePreview.tsx
@@ -1,22 +1,22 @@
 import { useState } from 'react'
 import type { Case } from '../../types'
 import { exportCases } from '../../lib/export-import'
+import { useCopiedState } from '../../hooks/useCopiedState'
 import CaseDetailView from './CaseDetailView'
 
 const GITHUB_REPO_URL = 'https://github.com/pwscup/syntheticdata-usecase-catalog'
 
 export default function CasePreview({ caseData, onBack }: { caseData: Case; onBack: () => void }) {
   const [showGuide, setShowGuide] = useState(false)
-  const [copied, setCopied] = useState(false)
+  const { copied, markCopied } = useCopiedState(3000)
 
   const suggestedPath = `public/cases/${caseData.id}/case.json`
 
   const handleGitHub = async () => {
     const json = JSON.stringify(caseData, null, 2)
     await navigator.clipboard.writeText(json)
-    setCopied(true)
+    markCopied()
     setShowGuide(true)
-    setTimeout(() => setCopied(false), 3000)
   }
 
   return (

--- a/src/components/case-form/AiAssistPanel.tsx
+++ b/src/components/case-form/AiAssistPanel.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react'
 import type { CaseFormData } from '../../schemas/case.schema'
 import { generateCreatePrompt, generateEnrichPrompt } from '../../constants/prompts'
 import { parseCaseFromAiOutput } from '../../lib/import-case'
+import { useCopiedState } from '../../hooks/useCopiedState'
 
 interface AiAssistPanelProps {
   mode: 'create' | 'edit'
@@ -12,7 +13,7 @@ interface AiAssistPanelProps {
 export default function AiAssistPanel({ mode, currentCaseJson, onImport }: AiAssistPanelProps) {
   const [isOpen, setIsOpen] = useState(false)
   const [isPromptExpanded, setIsPromptExpanded] = useState(false)
-  const [copied, setCopied] = useState(false)
+  const { copied, markCopied } = useCopiedState()
   const [importText, setImportText] = useState('')
   const [importStatus, setImportStatus] = useState<
     { type: 'success' } | { type: 'error'; message: string } | null
@@ -24,8 +25,7 @@ export default function AiAssistPanel({ mode, currentCaseJson, onImport }: AiAss
 
   async function handleCopy() {
     await navigator.clipboard.writeText(prompt)
-    setCopied(true)
-    setTimeout(() => setCopied(false), 2000)
+    markCopied()
   }
 
   function handleImport() {

--- a/src/components/case-list/CaseCard.tsx
+++ b/src/components/case-list/CaseCard.tsx
@@ -1,31 +1,14 @@
 import { Link } from 'react-router-dom'
 import type { Case } from '../../types'
+import { DOMAIN_COLORS, REGION_COLORS } from '../../constants/styles'
 
 interface CaseCardProps {
   caseItem: Case
 }
 
-const domainBorderColors: Record<string, string> = {
-  '金融': 'border-l-emerald-500',
-  '医療': 'border-l-rose-500',
-  '公共': 'border-l-indigo-500',
-  '通信': 'border-l-cyan-500',
-}
-
-const regionStyles: Record<string, string> = {
-  '国内': 'bg-blue-50 text-blue-700 ring-1 ring-blue-200',
-  '国外': 'bg-amber-50 text-amber-700 ring-1 ring-amber-200',
-}
-
-const domainStyles: Record<string, string> = {
-  '金融': 'bg-emerald-50 text-emerald-700 ring-1 ring-emerald-200',
-  '医療': 'bg-rose-50 text-rose-700 ring-1 ring-rose-200',
-  '公共': 'bg-indigo-50 text-indigo-700 ring-1 ring-indigo-200',
-  '通信': 'bg-cyan-50 text-cyan-700 ring-1 ring-cyan-200',
-}
-
 export default function CaseCard({ caseItem }: CaseCardProps) {
-  const borderColor = domainBorderColors[caseItem.domain] ?? 'border-l-gray-400'
+  const domainStyle = DOMAIN_COLORS[caseItem.domain as keyof typeof DOMAIN_COLORS]
+  const borderColor = domainStyle?.border ?? 'border-l-gray-400'
   const categoryText = Array.isArray(caseItem.usecase_category)
     ? caseItem.usecase_category.join(', ')
     : caseItem.usecase_category
@@ -56,11 +39,11 @@ export default function CaseCard({ caseItem }: CaseCardProps) {
       {/* Tags */}
       <div className="flex flex-wrap gap-1.5">
         {caseItem.region && (
-          <span className={`text-xs font-medium px-2 py-0.5 rounded-full ${regionStyles[caseItem.region] ?? 'bg-gray-100 text-gray-600'}`}>
+          <span className={`text-xs font-medium px-2 py-0.5 rounded-full ${REGION_COLORS[caseItem.region]?.badge ?? 'bg-gray-100 text-gray-600'}`}>
             {caseItem.region}
           </span>
         )}
-        <span className={`text-xs font-medium px-2 py-0.5 rounded-full ${domainStyles[caseItem.domain] ?? 'bg-gray-100 text-gray-600'}`}>
+        <span className={`text-xs font-medium px-2 py-0.5 rounded-full ${domainStyle?.badge ?? 'bg-gray-100 text-gray-600'}`}>
           {caseItem.domain}
         </span>
         {caseItem.tags.slice(0, 2).map((tag) => (

--- a/src/components/case-list/FilterPanel.tsx
+++ b/src/components/case-list/FilterPanel.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback } from 'react'
+import { useState, useCallback, useMemo } from 'react'
 import type { Case } from '../../types'
 import type { FilterState } from '../../hooks/useFilter'
 
@@ -10,8 +10,20 @@ interface FilterPanelProps {
   onClear: () => void
 }
 
-function countByFieldValue(cases: Case[], field: string, value: string): number {
-  return cases.filter(c => c[field as keyof Case] === value).length
+/** Build counts for all field values in a single pass */
+function buildFieldCounts(cases: Case[], field: string): Map<string, number> {
+  const counts = new Map<string, number>()
+  for (const c of cases) {
+    const value = c[field as keyof Case]
+    if (Array.isArray(value)) {
+      for (const v of value) {
+        if (typeof v === 'string') counts.set(v, (counts.get(v) ?? 0) + 1)
+      }
+    } else if (typeof value === 'string' && value) {
+      counts.set(value, (counts.get(value) ?? 0) + 1)
+    }
+  }
+  return counts
 }
 
 const filterSections: { key: keyof Omit<FilterState, 'query' | 'sortBy' | 'page'>; label: string }[] = [
@@ -22,6 +34,15 @@ const filterSections: { key: keyof Omit<FilterState, 'query' | 'sortBy' | 'page'
 
 export default function FilterPanel({ filters, filterOptions, filteredCases, onToggle, onClear }: FilterPanelProps) {
   const [isOpen, setIsOpen] = useState(false)
+
+  // Pre-compute counts per field in a single pass (instead of N+1 per option)
+  const fieldCounts = useMemo(() => {
+    const counts: Record<string, Map<string, number>> = {}
+    for (const section of filterSections) {
+      counts[section.key] = buildFieldCounts(filteredCases, section.key)
+    }
+    return counts
+  }, [filteredCases])
 
   const hasActiveFilters =
     filters.region.length > 0 ||
@@ -59,7 +80,7 @@ export default function FilterPanel({ filters, filterOptions, filteredCases, onT
             </h3>
             <div className="space-y-1">
               {options.map((option) => {
-                const count = countByFieldValue(filteredCases, section.key, option)
+                const count = fieldCounts[section.key]?.get(option) ?? 0
                 const isChecked = selected.includes(option)
                 const isZero = count === 0 && !isChecked
                 return (

--- a/src/components/case-list/SummaryPanel.tsx
+++ b/src/components/case-list/SummaryPanel.tsx
@@ -2,6 +2,7 @@ import { useMemo } from 'react'
 import type { Case } from '../../types'
 import { buildSummary, type CountItem } from '../../lib/summary'
 import { REGION_OPTIONS, DOMAIN_OPTIONS, USECASE_CATEGORY_OPTIONS } from '../../constants/categories'
+import { DOMAIN_COLORS, REGION_COLORS, CATEGORY_COLORS } from '../../constants/styles'
 import type { FilterState } from '../../hooks/useFilter'
 
 interface SummaryPanelProps {
@@ -73,42 +74,24 @@ function StackedBar({
   )
 }
 
-const regionColors: Record<string, string> = {
-  '国内': 'bg-blue-500',
-  '国外': 'bg-amber-500',
-}
-
-const domainColors: Record<string, string> = {
-  '金融': 'bg-emerald-500',
-  '医療': 'bg-rose-500',
-  '公共': 'bg-indigo-500',
-  '通信': 'bg-cyan-500',
-}
-
-const categoryColors: Record<string, string> = {
-  '組織内データ共有': 'bg-violet-500',
-  '組織間データ共有': 'bg-purple-500',
-  '外部分析者活用': 'bg-fuchsia-500',
-  'R&D': 'bg-sky-500',
-  'データ販売': 'bg-teal-500',
-  'フィージビリティ検証': 'bg-orange-500',
-}
+// Derived flat color maps for StackedBar (bg only)
+const regionColorMap = Object.fromEntries(
+  Object.entries(REGION_COLORS).map(([k, v]) => [k, v.bg]),
+)
+const domainColorMap = Object.fromEntries(
+  Object.entries(DOMAIN_COLORS).map(([k, v]) => [k, v.bg]),
+)
 
 export default function SummaryPanel({ filteredCases, totalCases, filters, onToggleFilter }: SummaryPanelProps) {
-  const summary = useMemo(() => buildSummary(filteredCases), [filteredCases])
-
-  const regionItems = useMemo(
-    () => mergeWithAllLabels(summary.byRegion, REGION_OPTIONS),
-    [summary],
-  )
-  const domainItems = useMemo(
-    () => mergeWithAllLabels(summary.byDomain, DOMAIN_OPTIONS),
-    [summary],
-  )
-  const categoryItems = useMemo(
-    () => mergeWithAllLabels(summary.byUsecaseCategory, USECASE_CATEGORY_OPTIONS),
-    [summary],
-  )
+  const { summary, regionItems, domainItems, categoryItems } = useMemo(() => {
+    const s = buildSummary(filteredCases)
+    return {
+      summary: s,
+      regionItems: mergeWithAllLabels(s.byRegion, REGION_OPTIONS),
+      domainItems: mergeWithAllLabels(s.byDomain, DOMAIN_OPTIONS),
+      categoryItems: mergeWithAllLabels(s.byUsecaseCategory, USECASE_CATEGORY_OPTIONS),
+    }
+  }, [filteredCases])
 
   const isFiltered = filteredCases.length !== totalCases
 
@@ -135,7 +118,7 @@ export default function SummaryPanel({ filteredCases, totalCases, filters, onTog
                 type="button"
                 title={`${r.label}: ${r.count}件 (${r.percentage}%)`}
                 onClick={() => onToggleFilter('region', r.label)}
-                className={`h-full transition-all duration-150 hover:brightness-110 ${regionColors[r.label] ?? 'bg-gray-400'}`}
+                className={`h-full transition-all duration-150 hover:brightness-110 ${regionColorMap[r.label] ?? 'bg-gray-400'}`}
                 style={{ width: `${r.percentage}%`, minWidth: r.percentage > 0 ? '4px' : '0' }}
               />
             ))}
@@ -158,7 +141,7 @@ export default function SummaryPanel({ filteredCases, totalCases, filters, onTog
                   }`}
                   disabled={r.count === 0}
                 >
-                  <span className={`inline-block w-2.5 h-2.5 rounded-sm shrink-0 ${regionColors[r.label] ?? 'bg-gray-400'}`} />
+                  <span className={`inline-block w-2.5 h-2.5 rounded-sm shrink-0 ${regionColorMap[r.label] ?? 'bg-gray-400'}`} />
                   {r.label}
                   <span className="font-semibold text-gray-800">{r.count}</span>
                   <span className="text-gray-400">({r.percentage}%)</span>
@@ -175,7 +158,7 @@ export default function SummaryPanel({ filteredCases, totalCases, filters, onTog
           <h3 className="text-sm font-semibold text-gray-700 mb-2">分野別</h3>
           <StackedBar
             items={domainItems}
-            colorMap={domainColors}
+            colorMap={domainColorMap}
             activeValues={filters.domain}
             onToggle={(v) => onToggleFilter('domain', v)}
           />
@@ -185,7 +168,7 @@ export default function SummaryPanel({ filteredCases, totalCases, filters, onTog
           <h3 className="text-sm font-semibold text-gray-700 mb-2">ユースケース分類別</h3>
           <StackedBar
             items={categoryItems}
-            colorMap={categoryColors}
+            colorMap={CATEGORY_COLORS}
             activeValues={filters.usecase_category}
             onToggle={(v) => onToggleFilter('usecase_category', v)}
           />

--- a/src/constants/styles.ts
+++ b/src/constants/styles.ts
@@ -1,0 +1,23 @@
+/** Domain ごとの色定義 */
+export const DOMAIN_COLORS = {
+  '金融': { bg: 'bg-emerald-500', border: 'border-l-emerald-500', badge: 'bg-emerald-50 text-emerald-700 ring-1 ring-emerald-200' },
+  '医療': { bg: 'bg-rose-500', border: 'border-l-rose-500', badge: 'bg-rose-50 text-rose-700 ring-1 ring-rose-200' },
+  '公共': { bg: 'bg-indigo-500', border: 'border-l-indigo-500', badge: 'bg-indigo-50 text-indigo-700 ring-1 ring-indigo-200' },
+  '通信': { bg: 'bg-cyan-500', border: 'border-l-cyan-500', badge: 'bg-cyan-50 text-cyan-700 ring-1 ring-cyan-200' },
+} as const
+
+/** Region ごとの色定義 */
+export const REGION_COLORS = {
+  '国内': { bg: 'bg-blue-500', badge: 'bg-blue-50 text-blue-700 ring-1 ring-blue-200' },
+  '国外': { bg: 'bg-amber-500', badge: 'bg-amber-50 text-amber-700 ring-1 ring-amber-200' },
+} as const
+
+/** ユースケース分類ごとの色定義 */
+export const CATEGORY_COLORS: Record<string, string> = {
+  '組織内データ共有': 'bg-violet-500',
+  '組織間データ共有': 'bg-purple-500',
+  '外部分析者活用': 'bg-fuchsia-500',
+  'R&D': 'bg-sky-500',
+  'データ販売': 'bg-teal-500',
+  'フィージビリティ検証': 'bg-orange-500',
+}

--- a/src/hooks/useCopiedState.ts
+++ b/src/hooks/useCopiedState.ts
@@ -1,0 +1,20 @@
+import { useState, useCallback, useRef, useEffect } from 'react'
+
+/**
+ * クリップボードコピー後の一時的なフィードバック状態を管理するhook。
+ * copied が true になった後、指定時間後に自動で false に戻る。
+ */
+export function useCopiedState(timeout = 2000) {
+  const [copied, setCopied] = useState(false)
+  const timerRef = useRef<ReturnType<typeof setTimeout>>(undefined)
+
+  const markCopied = useCallback(() => {
+    setCopied(true)
+    clearTimeout(timerRef.current)
+    timerRef.current = setTimeout(() => setCopied(false), timeout)
+  }, [timeout])
+
+  useEffect(() => () => clearTimeout(timerRef.current), [])
+
+  return { copied, markCopied }
+}


### PR DESCRIPTION
## Summary
- FilterPanel: N+1フルスキャンを1パスカウントに改善 (O(n*m) → O(n))、配列フィールド(usecase_category)のカウントバグも修正
- SummaryPanel: 4つのuseMemoを1つに統合
- 色定数を `src/constants/styles.ts` に共有化（CaseCard/SummaryPanelの重複削除）
- `useCopiedState` hook抽出（AiAssistPanel/CasePreviewの重複解消+タイマーleak修正）

## Test plan
- [x] `npx tsc -b --noEmit` 型エラーなし
- [x] `npx vitest run` 全155テストパス
- [x] フィルタパネルのカウント表示が正しいこと（特にユースケース分類）
- [x] グラフ凡例の色表示が変わっていないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)