### PR TITLE
feat: 免責事項・注意喚起の表示を追加・改善 (closes #9)

### DIFF
--- a/src/__tests__/AboutPage.test.tsx
+++ b/src/__tests__/AboutPage.test.tsx
@@ -19,16 +19,29 @@ describe('AboutPage', () => {
       </MemoryRouter>,
     )
     expect(screen.getByText('免責事項')).toBeInTheDocument()
-    expect(screen.getByText(/情報提供を目的としており/)).toBeInTheDocument()
+    expect(screen.getByText(/正確性、完全性、最新性について保証するものではありません/)).toBeInTheDocument()
   })
 
-  it('機微情報警告が表示される', () => {
+  it('機微情報の取り扱いについてが表示される', () => {
     render(
       <MemoryRouter>
         <AboutPage />
       </MemoryRouter>,
     )
-    expect(screen.getByText('機微情報に関する警告')).toBeInTheDocument()
-    expect(screen.getByText(/個人情報、顧客識別情報等の機微情報を入力しないでください/)).toBeInTheDocument()
+    expect(screen.getByText('機微情報の取り扱いについて')).toBeInTheDocument()
+    expect(screen.getByText(/機微情報を入力しないでください/)).toBeInTheDocument()
+  })
+
+  it('問い合わせ先が表示される', () => {
+    render(
+      <MemoryRouter>
+        <AboutPage />
+      </MemoryRouter>,
+    )
+    expect(screen.getByText('ご要望・お問い合わせ')).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: 'Issue' })).toHaveAttribute(
+      'href',
+      'https://github.com/pwscup/syntheticdata-usecase-catalog/issues',
+    )
   })
 })

--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -1,7 +1,17 @@
+import { Link } from 'react-router-dom'
+
 export default function Footer() {
   return (
-    <footer className="bg-gray-100 text-gray-500 text-center py-4 text-sm border-t">
-      &copy; 2026 合成データ ユースケースカタログ
+    <footer className="bg-gray-50 text-center py-4 text-sm border-t border-gray-200">
+      <p className="text-gray-400 text-xs mb-1">
+        掲載情報は正確性を保証するものではありません。
+        <Link to="/about" className="text-blue-500 hover:text-blue-600 underline underline-offset-2 ml-0.5">
+          免責事項
+        </Link>
+      </p>
+      <p className="text-gray-400 text-xs">
+        &copy; 2026 合成データ ユースケースカタログ
+      </p>
     </footer>
   )
 }

--- a/src/pages/AboutPage.tsx
+++ b/src/pages/AboutPage.tsx
@@ -6,24 +6,48 @@ export default function AboutPage() {
       <section className="space-y-2">
         <h2 className="text-lg font-semibold">概要</h2>
         <p className="text-gray-700">
-          本アプリケーションは、合成データの活用事例を収集・整理し、検索・閲覧できるカタログです。
+          本カタログは、合成データ（Synthetic Data）の活用事例を収集・整理し、検索・閲覧できるWebカタログです。
           国内外の多様な分野における合成データの活用方法、安全性評価、有用性評価の情報を提供します。
         </p>
       </section>
 
-      <section className="p-4 bg-yellow-50 border border-yellow-300 rounded-md space-y-2">
-        <h2 className="text-lg font-semibold text-yellow-800">免責事項</h2>
-        <p className="text-yellow-900 text-sm">
-          本アプリケーションは情報提供を目的としており、掲載内容の正確性・完全性を保証するものではありません。
-          掲載情報に基づく判断・行動については、利用者ご自身の責任において行ってください。
+      <section className="p-5 bg-slate-50 border border-slate-200 rounded-lg space-y-2">
+        <h2 className="text-base font-semibold text-slate-700 flex items-center gap-2">
+          <span className="text-lg">{'\u2139\uFE0F'}</span>
+          免責事項
+        </h2>
+        <p className="text-slate-600 text-sm leading-relaxed">
+          本カタログに掲載されている情報は、公開情報およびヒアリング等を通じて調査した内容に基づき作成しています。
+          掲載内容の正確性、完全性、最新性について保証するものではありません。
+          また、掲載内容は予告なく変更・削除される場合があります。
+          本カタログの情報に基づく判断や行動については、利用者ご自身の責任において行ってください。
         </p>
       </section>
 
-      <section className="p-4 bg-red-50 border border-red-300 rounded-md space-y-2">
-        <h2 className="text-lg font-semibold text-red-800">機微情報に関する警告</h2>
-        <p className="text-red-900 text-sm">
-          個人情報、顧客識別情報等の機微情報を入力しないでください。
-          本アプリケーションはLocalStorageにデータを保存するため、機微情報の安全な管理には適していません。
+      <section className="p-5 bg-red-50 border border-red-200 rounded-lg space-y-2">
+        <h2 className="text-base font-semibold text-red-700 flex items-center gap-2">
+          <span className="text-lg">{'\u26A0\uFE0F'}</span>
+          機微情報の取り扱いについて
+        </h2>
+        <p className="text-red-800 text-sm leading-relaxed">
+          本カタログの検索・フィルター機能において、個人情報、顧客識別情報、その他の機微情報を入力しないでください。
+          入力された情報はブラウザの操作履歴やURL等に残る可能性があり、機微情報の安全な取り扱いを保証できません。
+        </p>
+      </section>
+
+      <section className="p-5 bg-gray-50 border border-gray-200 rounded-lg space-y-2">
+        <h2 className="text-base font-semibold text-gray-700">ご要望・お問い合わせ</h2>
+        <p className="text-gray-600 text-sm leading-relaxed">
+          掲載情報の修正や新しい事例の追加など、ご要望やお気づきの点がございましたら、GitHubの
+          <a
+            href="https://github.com/pwscup/syntheticdata-usecase-catalog/issues"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-blue-600 hover:underline"
+          >
+            Issue
+          </a>
+          にてお知らせください。
         </p>
       </section>
 

--- a/src/pages/CaseDetailPage.tsx
+++ b/src/pages/CaseDetailPage.tsx
@@ -36,6 +36,11 @@ export default function CaseDetailPage() {
           編集
         </Link>
       </div>
+
+      <p className="text-xs text-gray-400 mb-6">
+        ※ 本事例の情報は公開資料等に基づき作成したものであり、内容の正確性を保証するものではありません。最新の情報は出典元をご確認ください。
+        詳細は<Link to="/about" className="text-blue-400 hover:text-blue-500 underline underline-offset-2 ml-0.5">Aboutページ</Link>をご確認ください。
+      </p>
     </div>
   )
 }


### PR DESCRIPTION
## Summary

- About画面の免責文言を刷新（正確性・完全性・最新性の非保証、予告なき変更、自己責任を明記）
- 古いLocalStorage記載を削除し、機微情報の取り扱い注意に変更
- GitHub Issueでの問い合わせ案内セクションを追加
- 全ページ共通フッターに免責注記とAboutリンクを追加
- 事例詳細ページ下部に正確性非保証の注記とAboutリンクを追加

## 設計方針

3つの専門的観点から検討した結果を統合:

| 観点 | 内容 |
|------|------|
| 法律 | NTT秘密計算事例集の免責文言を参考に、責任範囲を明確化する4要素（公開情報ベース、正確性非保証、予告なき変更、自己責任）を網羅 |
| デザイン | 免責→slate系（情報通知）、機微情報→red系（注意）、フッター/詳細注記→gray-400（控えめなリマインダー）と段階的に使い分け |
| エンジニア | フッター常時表示 + About画面 + 事例詳細注記の3層構造。初回バナー/モーダルは不要と判断（個人データ非収集、UX阻害回避） |

## 変更ファイル

- `src/pages/AboutPage.tsx` — 免責・機微情報・問い合わせセクション刷新
- `src/components/layout/Footer.tsx` — 注意喚起メッセージ+Aboutリンク追加
- `src/pages/CaseDetailPage.tsx` — 事例下部に注記追加
- `src/__tests__/AboutPage.test.tsx` — テスト更新・追加

## Test plan

- [x] About画面で免責事項が正しく表示されること
- [x] About画面で機微情報の取り扱い注意が表示されること（LocalStorage記載がないこと）
- [x] About画面でGitHub Issueリンクが正しく動作すること
- [x] 全ページのフッターに注意喚起メッセージと免責事項リンクが表示されること
- [x] 事例詳細ページ下部に注記とAboutリンクが表示されること
- [x] モバイル表示でも各注記が適切に表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)