### PR TITLE
feat: 事例レポートから17件の合成データ活用事例を追加

### DIFF
--- a/public/cases/rpt-0001/case.json
+++ b/public/cases/rpt-0001/case.json
@@ -1,0 +1,50 @@
+{
+  "id": "rpt-0001",
+  "title": "肺がん死亡リスク予測モデル開発のための合成データ活用",
+  "region": "国外",
+  "domain": "医療",
+  "organization": "HRA (Health Research Authority) / ICO",
+  "usecase_category": [
+    "R&D"
+  ],
+  "summary": "NHSが、肺がん死亡リスク予測モデルの開発可能性を検証するため、実患者データからGAN（敵対的生成ネットワーク）を用いて合成データを生成した事例。モデル性能だけでなく、残余識別リスクや匿名化の判断基準も検討しており、医療分野での合成データ活用のガバナンスを包括的に扱っている。",
+  "value_proposition": "患者の個人情報を保護しつつ、実データと同等の統計特性を持つ合成データで予測モデルの開発・検証を実施。匿名化判断やガバナンス上の考慮事項を体系化し、医療分野での合成データ活用の指針を示した。",
+  "synthetic_generation_method": "GAN（敵対的生成ネットワーク）を使用して、実患者データから合成データを生成。",
+  "safety_evaluation_method": "k-匿名性指標と多様性指標で匿名性を評価。リンケージ攻撃や属性推論攻撃による再識別リスクを検証。認定研究者のみにデータアクセス契約を通じたアクセスを許可し、ISO認証されたセキュア環境で管理。",
+  "utility_evaluation_method": "Wasserstein距離やJensen-Shannon距離で統計的類似性を評価。Alpha-precision/Beta-recall指標で統計的特性の保持を確認。合成データで構築したリスク予測モデルの識別精度が実データ同等であることを実証。",
+  "tags": [
+    "肺がん",
+    "GAN",
+    "予測モデル",
+    "ガバナンス",
+    "PETs"
+  ],
+  "sources": [
+    {
+      "source_type": "web",
+      "title": "NHS: Governance Considerations for the Use of Synthetic Data in Health and Care Research",
+      "url": "https://www.digitalregulations.innovation.nhs.uk/case-studies/governance-considerations-for-the-use-of-synthetic-data-in-health-and-care-research/",
+      "note": "NHSによる合成データガバナンスのケーススタディ"
+    }
+  ],
+  "figures": [
+    {
+      "type": "data_flow",
+      "title": "肺がんリスク予測のための合成データ活用フロー",
+      "data": {
+        "nodes": [
+          { "id": "s1", "label": "実患者データ（肺がん関連）", "category": "source" },
+          { "id": "s2", "label": "患者プライバシー保護の要件", "category": "constraint" },
+          { "id": "p1", "label": "GANにより合成患者データを生成", "category": "process" },
+          { "id": "a1", "label": "肺がん死亡リスク予測モデルの開発・検証", "category": "application" },
+          { "id": "a2", "label": "モデル性能と残余識別リスクの評価を両立", "category": "outcome" }
+        ],
+        "edges": []
+      },
+      "note": ""
+    }
+  ],
+  "status": "draft",
+  "created_at": "2026-03-06T00:00:00+09:00",
+  "updated_at": "2026-03-06T00:00:00+09:00"
+}

--- a/public/cases/rpt-0002/case.json
+++ b/public/cases/rpt-0002/case.json
@@ -1,0 +1,50 @@
+{
+  "id": "rpt-0002",
+  "title": "SynthVAEによる模擬患者データの生成と評価手順の整備",
+  "region": "国外",
+  "domain": "医療",
+  "organization": "NHS England",
+  "usecase_category": [
+    "R&D"
+  ],
+  "summary": "NHS Englandが、SynthVAE（変分オートエンコーダベースの合成データ生成手法）を使って模擬患者データを生成し、その評価方法や再利用可能な手順を整備した事例。生成・評価・文書化までの一連のプロセスを公開しており、他機関での再現が可能な実務的な取り組み。",
+  "value_proposition": "合成患者データの生成から品質評価、文書化までの一連の手順を再利用可能な形で整備。他の医療機関やNHS内の組織が同様の取り組みを実施する際のテンプレートとして活用できる。",
+  "synthetic_generation_method": "SynthVAE（変分オートエンコーダ: VAEベース）をPyTorchで実装し、MIMIC-III（公開病院治療記録）で検証。オプションで差分プライバシー（Opacus）を適用可能。QuantumBlackのKedroフレームワークでパイプライン化し、データ生成からモデル学習、合成データ生成、評価までを単一コマンドで実行可能。",
+  "safety_evaluation_method": "差分プライバシーをVAE学習時に適用可能。合成データと実データに同一レコードが存在しないことを確認。メンバーシップ推論攻撃による情報漏洩リスクも評価。再識別リスクの低減を確認するが、完全な排除ではないことも明示。",
+  "utility_evaluation_method": "Synthetic Data Vault（SDV）の評価指標（SVCDetection、GMLogLikelihood、CSTest、KSTestExtended、KLダイバージェンス）を使用。有用性（Utility）、品質（Quality）、プライバシー（Privacy）の3次元で評価。Webベースのレポートで視覚的な比較も提供。",
+  "tags": [
+    "SynthVAE",
+    "VAE",
+    "評価手順",
+    "再利用可能",
+    "PETs"
+  ],
+  "sources": [
+    {
+      "source_type": "web",
+      "title": "NHS England: Exploring how to create mock patient data - What we did",
+      "url": "https://digital.nhs.uk/services/ai-knowledge-repository/case-studies/exploring-how-to-create-mock-patient-data-synthetic-data-from-real-patient-data/what-we-did",
+      "note": "NHS Englandによる模擬患者データ生成の取り組み"
+    }
+  ],
+  "figures": [
+    {
+      "type": "data_flow",
+      "title": "SynthVAEによる模擬患者データ生成フロー",
+      "data": {
+        "nodes": [
+          { "id": "s1", "label": "NHS実患者データ", "category": "source" },
+          { "id": "s2", "label": "患者プライバシー保護と再利用性の要件", "category": "constraint" },
+          { "id": "p1", "label": "SynthVAEで模擬患者データを生成", "category": "process" },
+          { "id": "a1", "label": "生成・評価・文書化の手順を整備", "category": "application" },
+          { "id": "a2", "label": "他機関でも再利用可能なテンプレートを公開", "category": "outcome" }
+        ],
+        "edges": []
+      },
+      "note": ""
+    }
+  ],
+  "status": "draft",
+  "created_at": "2026-03-06T00:00:00+09:00",
+  "updated_at": "2026-03-06T00:00:00+09:00"
+}

--- a/public/cases/rpt-0003/case.json
+++ b/public/cases/rpt-0003/case.json
@@ -1,0 +1,51 @@
+{
+  "id": "rpt-0003",
+  "title": "退役軍人医療機関における合成データ基盤の導入",
+  "region": "国外",
+  "domain": "医療",
+  "organization": "VHA (Veterans Health Administration) / MDClone",
+  "usecase_category": [
+    "組織内データ共有"
+  ],
+  "summary": "米国最大の統合医療システムであるVHA（退役軍人保健局: 1,298施設・900万人以上の退役軍人に医療提供）が、MDClone社の合成データ生成基盤を導入した事例。200万人の患者コホートからオンデマンドで合成データを生成し、IRB審査なしで心不全再入院予測や自殺予防などの分析・ML開発を推進。",
+  "value_proposition": "従来は数か月かかっていたIRB審査や情報アクセス承認を経ずに、医療従事者が必要なデータに即座にアクセス可能に。ケアパス分析や業務改善のスピードを大幅に向上させた。",
+  "synthetic_generation_method": "MDClone社の合成データ生成プラットフォームを使用。実患者データの統計的特性を保持した高品質な合成データを自動生成。",
+  "safety_evaluation_method": "合成データには実在の患者情報が含まれないため、IRB審査なしでの利用が可能。MDCloneプラットフォームの品質保証機能により、個人特定リスクを排除。",
+  "utility_evaluation_method": "合成データでMLモデルを構築し、実データで検証する方式で精度を確認。心不全再入院予測アルゴリズムの開発、自殺予防施策（10%削減目標）のデータ分析に活用し、実務的有用性を実証。",
+  "tags": [
+    "退役軍人",
+    "迅速アクセス",
+    "IRB不要",
+    "業務改善",
+    "MDClone",
+    "PETs"
+  ],
+  "sources": [
+    {
+      "source_type": "web",
+      "title": "MDClone: Using High-Quality Synthetic Data to Support Rapid Innovation - VHA Innovation",
+      "url": "https://mdclone.com/customer-story/using-high-quality-synthetic-data-to-support-rapid-innovation-vha-innovation/",
+      "note": "MDCloneによるVHA事例紹介"
+    }
+  ],
+  "figures": [
+    {
+      "type": "data_flow",
+      "title": "VHAにおける合成データ基盤活用フロー",
+      "data": {
+        "nodes": [
+          { "id": "s1", "label": "VHA患者データ", "category": "source" },
+          { "id": "s2", "label": "IRB審査・情報アクセス承認に長期間", "category": "constraint" },
+          { "id": "p1", "label": "MDCloneで合成患者データを即座に生成", "category": "process" },
+          { "id": "a1", "label": "ケアパス分析・業務改善に活用", "category": "application" },
+          { "id": "a2", "label": "審査不要で迅速なデータアクセスを実現", "category": "outcome" }
+        ],
+        "edges": []
+      },
+      "note": ""
+    }
+  ],
+  "status": "draft",
+  "created_at": "2026-03-06T00:00:00+09:00",
+  "updated_at": "2026-03-06T00:00:00+09:00"
+}

--- a/public/cases/rpt-0004/case.json
+++ b/public/cases/rpt-0004/case.json
@@ -1,0 +1,50 @@
+{
+  "id": "rpt-0004",
+  "title": "合成データの精度検証と患者プライバシー保護の両立",
+  "region": "国外",
+  "domain": "医療",
+  "organization": "Washington University in St. Louis / MDClone",
+  "usecase_category": [
+    "R&D"
+  ],
+  "summary": "ワシントン大学セントルイス校が、MDClone社と連携して3つのパイロットプロジェクトを実施し、合成データの精度と患者プライバシー保護の両立を検証した事例。従来の脱識別化（de-identification）では研究価値が低下するという課題に対し、合成データが有効な代替手段であることを実証。",
+  "value_proposition": "従来の脱識別化手法では研究に必要な情報が失われる問題を解決。合成データにより、患者プライバシーを保護しつつ、研究に必要な複雑なデータ構造と統計的特性を維持できることを3つのパイロットで実証。",
+  "synthetic_generation_method": "MDClone社の合成データ生成プラットフォームを使用。複雑な患者データの統計的特性を保持した合成データを生成。",
+  "safety_evaluation_method": "3つのパイロットプロジェクトを通じて、合成データから実在の患者を特定できないことを体系的に検証。従来の脱識別化と比較した安全性評価を実施。",
+  "utility_evaluation_method": "3つのパイロット（頭部外傷重症度予測、敗血症予測、性感染症分析）で、合成データで学習したMLモデルが実データに適用した際の性能を検証。査読付き論文（Frontiers in Digital Health）での心不全死亡率予測にも合成データを使用し、学術的有用性も実証。",
+  "tags": [
+    "パイロット検証",
+    "脱識別化代替",
+    "研究データ",
+    "MDClone",
+    "PETs"
+  ],
+  "sources": [
+    {
+      "source_type": "web",
+      "title": "MDClone: Three Pilot Projects Ensure Synthetic Data Accuracy - Washington University",
+      "url": "https://mdclone.com/customer-story/three-pilot-projects-ensure-synthetic-data-accuracy-and-maintained-patient-privacy-washington-university/",
+      "note": "MDCloneによるワシントン大学事例紹介"
+    }
+  ],
+  "figures": [
+    {
+      "type": "data_flow",
+      "title": "合成データ精度検証のパイロットフロー",
+      "data": {
+        "nodes": [
+          { "id": "s1", "label": "ワシントン大学の患者データ", "category": "source" },
+          { "id": "s2", "label": "脱識別化では研究価値が低下", "category": "constraint" },
+          { "id": "p1", "label": "MDCloneで合成データを生成", "category": "process" },
+          { "id": "a1", "label": "3つのパイロットで精度と安全性を検証", "category": "application" },
+          { "id": "a2", "label": "プライバシー保護と研究価値の両立を実証", "category": "outcome" }
+        ],
+        "edges": []
+      },
+      "note": ""
+    }
+  ],
+  "status": "draft",
+  "created_at": "2026-03-06T00:00:00+09:00",
+  "updated_at": "2026-03-06T00:00:00+09:00"
+}

--- a/public/cases/rpt-0005/case.json
+++ b/public/cases/rpt-0005/case.json
@@ -1,0 +1,51 @@
+{
+  "id": "rpt-0005",
+  "title": "州全体レベルでの合成電子カルテデータの活用",
+  "region": "国外",
+  "domain": "医療",
+  "organization": "South Australia Health / Gretel",
+  "usecase_category": [
+    "組織内データ共有",
+    "R&D"
+  ],
+  "summary": "南オーストラリア州の公的医療システムが、Gretel社のプラットフォームを用いて実電子カルテ（EHR）から合成データを生成し、患者プライバシーを保護しながら臨床研究や患者ケアの改善に活用している事例。州全体レベルでの公的医療システムにおける合成データ導入事例。",
+  "value_proposition": "州全体の公的医療システムで、患者のプライバシーを保護しながら臨床研究やケア改善に必要なデータを広く活用可能に。部門間のデータ共有障壁を低減し、医療サービスの質の向上を推進。",
+  "synthetic_generation_method": "Gretel社の合成データ生成プラットフォームを使用。実電子カルテ（EHR）データの統計的特性を保持した合成データを生成。",
+  "safety_evaluation_method": "合成データには実在の患者情報が含まれないため、患者プライバシーを保護。Gretelプラットフォームのプライバシー保護機能を活用。",
+  "utility_evaluation_method": "合成データを用いた臨床研究や患者ケア改善の分析結果の精度を検証。",
+  "tags": [
+    "電子カルテ",
+    "州全体導入",
+    "臨床研究",
+    "Gretel",
+    "PETs"
+  ],
+  "sources": [
+    {
+      "source_type": "web",
+      "title": "Gretel Customer Case Study: South Australia Health",
+      "url": "https://info.gretel.ai/case-study-sa-health",
+      "note": "Gretelによる南オーストラリア州保健局事例紹介"
+    }
+  ],
+  "figures": [
+    {
+      "type": "data_flow",
+      "title": "州全体レベルの合成EHRデータ活用フロー",
+      "data": {
+        "nodes": [
+          { "id": "s1", "label": "南オーストラリア州の電子カルテ（EHR）", "category": "source" },
+          { "id": "s2", "label": "患者プライバシーによるデータ共有制約", "category": "constraint" },
+          { "id": "p1", "label": "Gretelで合成EHRデータを生成", "category": "process" },
+          { "id": "a1", "label": "臨床研究・患者ケア改善に活用", "category": "application" },
+          { "id": "a2", "label": "州全体で安全なデータ活用環境を構築", "category": "outcome" }
+        ],
+        "edges": []
+      },
+      "note": ""
+    }
+  ],
+  "status": "draft",
+  "created_at": "2026-03-06T00:00:00+09:00",
+  "updated_at": "2026-03-06T00:00:00+09:00"
+}

--- a/public/cases/rpt-0006/case.json
+++ b/public/cases/rpt-0006/case.json
@@ -1,0 +1,53 @@
+{
+  "id": "rpt-0006",
+  "title": "ゲノム研究向け安全な合成データセットの作成と共有",
+  "region": "国外",
+  "domain": "医療",
+  "domain_sub": "ゲノム",
+  "organization": "Illumina / Gretel",
+  "usecase_category": [
+    "組織間データ共有",
+    "R&D"
+  ],
+  "summary": "ゲノム解析大手のIlluminaが、Gretel社と連携してゲノム研究向けの安全な合成データセットを作成し、研究者・医療機関・産業界の間でプライバシーを保護しながらデータ共有を可能にした事例。ゲノムデータという最もセンシティブな医療データの合成データ活用事例として重要。",
+  "value_proposition": "ゲノムデータは個人の遺伝情報を含む最もセンシティブなデータの一つ。合成データにより、研究者間・機関間でのデータ共有の障壁を大幅に低減し、ゲノム研究の進展を加速。",
+  "synthetic_generation_method": "Gretel社の合成データ生成プラットフォームを使用。ゲノムデータの統計的特性を保持した合成データセットを生成。",
+  "safety_evaluation_method": "合成データから実在の個人のゲノム情報を復元できないことを検証。Gretelプラットフォームのプライバシー保護機能を活用。",
+  "utility_evaluation_method": "合成ゲノムデータが研究目的に十分な統計的特性を持つことを検証。",
+  "tags": [
+    "ゲノム",
+    "遺伝情報",
+    "データ共有",
+    "Illumina",
+    "Gretel",
+    "PETs"
+  ],
+  "sources": [
+    {
+      "source_type": "web",
+      "title": "Gretel Customer Case Study: Illumina",
+      "url": "https://info.gretel.ai/case-study-illumina",
+      "note": "GretelによるIllumina事例紹介"
+    }
+  ],
+  "figures": [
+    {
+      "type": "data_flow",
+      "title": "ゲノム研究向け合成データ共有フロー",
+      "data": {
+        "nodes": [
+          { "id": "s1", "label": "Illuminaのゲノムデータ", "category": "source" },
+          { "id": "s2", "label": "遺伝情報の高い機密性によるデータ共有制約", "category": "constraint" },
+          { "id": "p1", "label": "Gretelで合成ゲノムデータを生成", "category": "process" },
+          { "id": "a1", "label": "研究者・医療機関・産業界間でデータ共有", "category": "application" },
+          { "id": "a2", "label": "プライバシー保護とゲノム研究の進展を両立", "category": "outcome" }
+        ],
+        "edges": []
+      },
+      "note": ""
+    }
+  ],
+  "status": "draft",
+  "created_at": "2026-03-06T00:00:00+09:00",
+  "updated_at": "2026-03-06T00:00:00+09:00"
+}

--- a/public/cases/rpt-0007/case.json
+++ b/public/cases/rpt-0007/case.json
@@ -1,0 +1,52 @@
+{
+  "id": "rpt-0007",
+  "title": "1,600万件の合成患者記録によるML モデル学習基盤の構築",
+  "region": "国外",
+  "domain": "医療",
+  "organization": "大手医療機関（2,000以上の拠点） / Gretel",
+  "usecase_category": [
+    "組織内データ共有",
+    "R&D"
+  ],
+  "summary": "米国の2,000以上の拠点を持つ大規模病院ネットワークが、Gretel社のプラットフォームを用いて分娩関連の合成患者記録を1,600万件以上生成し、患者予測やオペレーション最適化のための機械学習モデルの学習データとして活用した事例。",
+  "value_proposition": "実際の患者データを使わずに1,600万件規模の合成データを生成し、MLモデルの学習に活用。患者プライバシーを保護しつつ、患者予測精度の向上と病院運営の効率化を実現。",
+  "synthetic_generation_method": "Gretel社の合成データ生成プラットフォームを使用。分娩関連の患者記録の統計的特性を保持した1,600万件以上の合成レコードを生成。",
+  "safety_evaluation_method": "合成データには実在の患者情報が含まれず、個人の特定は不可能。実患者データを一切外部に露出させずにMLモデルの学習を実現。",
+  "utility_evaluation_method": "合成データで学習したMLモデルの患者予測精度と病院運営改善効果を検証。",
+  "tags": [
+    "ML学習データ",
+    "患者予測",
+    "大規模生成",
+    "分娩",
+    "Gretel",
+    "PETs"
+  ],
+  "sources": [
+    {
+      "source_type": "web",
+      "title": "Gretel Customer Case Study: Major Healthcare Institution",
+      "url": "https://info.gretel.ai/case-study-major-healthcare-institution",
+      "note": "Gretelによる大手医療機関事例紹介"
+    }
+  ],
+  "figures": [
+    {
+      "type": "data_flow",
+      "title": "大規模合成患者データによるML学習フロー",
+      "data": {
+        "nodes": [
+          { "id": "s1", "label": "病院ネットワークの患者記録（分娩関連）", "category": "source" },
+          { "id": "s2", "label": "患者プライバシーによるML学習データの制約", "category": "constraint" },
+          { "id": "p1", "label": "Gretelで1,600万件超の合成患者記録を生成", "category": "process" },
+          { "id": "a1", "label": "患者予測・オペレーション最適化のMLモデル学習", "category": "application" },
+          { "id": "a2", "label": "プライバシー保護とML精度向上を両立", "category": "outcome" }
+        ],
+        "edges": []
+      },
+      "note": ""
+    }
+  ],
+  "status": "draft",
+  "created_at": "2026-03-06T00:00:00+09:00",
+  "updated_at": "2026-03-06T00:00:00+09:00"
+}

--- a/public/cases/rpt-0008/case.json
+++ b/public/cases/rpt-0008/case.json
@@ -1,0 +1,52 @@
+{
+  "id": "rpt-0008",
+  "title": "150万件の合成患者レコードによるデータサンドボックスの公開",
+  "region": "国外",
+  "domain": "医療",
+  "domain_sub": "保険",
+  "organization": "Humana / MOSTLY AI",
+  "usecase_category": [
+    "外部分析者活用",
+    "データ販売"
+  ],
+  "summary": "全米第3位の医療保険会社Humanaが、MOSTLY AI社の技術を用いて150万件の合成患者レコードを生成し、外部開発者やデータサイエンティストが本番に近い環境で検証できるデータサンドボックスを公開した事例。人口統計、保険適用、医療・薬局請求、診断コード等を含む包括的なデータセット。",
+  "value_proposition": "規制が厳しい医療保険業界において、実データを外部に出さずに外部開発者やパートナーがリアルなデータ環境で製品検証できるサンドボックスを構築。製品開発サイクルの高速化と外部エコシステムとの連携を実現。",
+  "synthetic_generation_method": "MOSTLY AI社のAI合成データ生成技術を使用。150万件の合成患者レコードを生成し、変数間の相関や関係性を保持。ダッシュボードでの即時アクセス、サンプルデータのダウンロード、データ辞書を備えたサンドボックスとして提供。",
+  "safety_evaluation_method": "合成データは患者の匿名性を完全に維持しつつ、テストに必要な具体性と文脈的な関係性を保持。実在の患者との対応関係が存在しない「完全に安全な」データとして設計。",
+  "utility_evaluation_method": "合成データの品質とリアリズムを重視し、元データの変数間の相関と関係性が保持されていることを検証。外部開発者が患者コホートの特定や顧客体験の改善に活用できることを確認。",
+  "tags": [
+    "データサンドボックス",
+    "外部公開",
+    "保険請求",
+    "MOSTLY AI",
+    "PETs"
+  ],
+  "sources": [
+    {
+      "source_type": "web",
+      "title": "MOSTLY AI: The Humana synthetic data sandbox for winning data-centric products",
+      "url": "https://mostly.ai/blog/synthetic-healthcare-data-sandbox",
+      "note": "MOSTLY AIによるHumanaサンドボックス事例紹介"
+    }
+  ],
+  "figures": [
+    {
+      "type": "data_flow",
+      "title": "Humana合成データサンドボックスのフロー",
+      "data": {
+        "nodes": [
+          { "id": "s1", "label": "Humana会員の医療保険データ（人口統計・請求・診断）", "category": "source" },
+          { "id": "s2", "label": "医療保険の規制による外部データ共有制約", "category": "constraint" },
+          { "id": "p1", "label": "MOSTLY AIで150万件の合成患者レコードを生成", "category": "process" },
+          { "id": "a1", "label": "外部開発者・データサイエンティスト向けサンドボックスとして公開", "category": "application" },
+          { "id": "a2", "label": "安全なデータ環境で製品検証・開発を加速", "category": "outcome" }
+        ],
+        "edges": []
+      },
+      "note": ""
+    }
+  ],
+  "status": "draft",
+  "created_at": "2026-03-06T00:00:00+09:00",
+  "updated_at": "2026-03-06T00:00:00+09:00"
+}

--- a/public/cases/rpt-0009/case.json
+++ b/public/cases/rpt-0009/case.json
@@ -1,0 +1,52 @@
+{
+  "id": "rpt-0009",
+  "title": "GDPR準拠の合成データによる自動車保険AIモデル開発",
+  "region": "国外",
+  "domain": "金融",
+  "domain_sub": "保険",
+  "organization": "BeRebel / Aindo",
+  "usecase_category": [
+    "R&D"
+  ],
+  "summary": "イタリアの自動車保険会社BeRebelが、Aindo社の合成データプラットフォームを用い、IVASS（イタリア保険規制当局）のレギュラトリーサンドボックス内でGDPR準拠のAIモデルを開発した事例。合成データで学習したモデルの精度は実データ比99%を達成し、データ準備期間は75%以上短縮された。",
+  "value_proposition": "GDPRと保険業界固有の規制の両方に準拠しつつ、実データに匹敵する精度（99%）のAIモデルを開発。データ準備期間を75%以上短縮し、規制サンドボックスでの検証も完了。",
+  "synthetic_generation_method": "Aindo社の合成データ生成プラットフォームを使用。保険関連の表形式データから、統計的特性を保持した合成データを生成。",
+  "safety_evaluation_method": "GDPR準拠およびイタリア保険規制（IVASS）のレギュラトリーサンドボックス内で検証。合成データがプライバシー保護要件を満たすことを規制当局の枠組みの下で確認。",
+  "utility_evaluation_method": "合成データで学習したAIモデルの精度を実データで学習したモデルと比較。99%の精度一致を達成。また、データ準備期間（time-to-data）が75%以上短縮されたことを計測。",
+  "tags": [
+    "自動車保険",
+    "GDPR",
+    "規制サンドボックス",
+    "99%精度",
+    "Aindo",
+    "PETs"
+  ],
+  "sources": [
+    {
+      "source_type": "web",
+      "title": "Aindo: New case study about synthetic data in insurance - BeRebel",
+      "url": "https://www.aindo.com/news/berebelcasestudy/",
+      "note": "AindoによるBeRebel事例紹介"
+    }
+  ],
+  "figures": [
+    {
+      "type": "data_flow",
+      "title": "GDPR準拠の合成データによる保険AIモデル開発フロー",
+      "data": {
+        "nodes": [
+          { "id": "s1", "label": "BeRebelの自動車保険データ", "category": "source" },
+          { "id": "s2", "label": "GDPR・保険規制によるデータ利用制約", "category": "constraint" },
+          { "id": "p1", "label": "Aindoプラットフォームで合成データを生成", "category": "process" },
+          { "id": "a1", "label": "IVASSサンドボックスでAIモデルを開発・検証", "category": "application" },
+          { "id": "a2", "label": "実データ比99%精度・データ準備75%短縮を実現", "category": "outcome" }
+        ],
+        "edges": []
+      },
+      "note": ""
+    }
+  ],
+  "status": "draft",
+  "created_at": "2026-03-06T00:00:00+09:00",
+  "updated_at": "2026-03-06T00:00:00+09:00"
+}

--- a/public/cases/rpt-0010/case.json
+++ b/public/cases/rpt-0010/case.json
@@ -1,0 +1,50 @@
+{
+  "id": "rpt-0010",
+  "title": "大手アジア銀行における部門横断の即時合成データ生成基盤",
+  "region": "国外",
+  "domain": "金融",
+  "organization": "大手アジア銀行（Tier 1） / Betterdata",
+  "usecase_category": [
+    "組織内データ共有"
+  ],
+  "summary": "データ利用承認に数か月を要していたアジアの大手銀行が、Betterdata社のオンプレミス合成データ生成プラットフォームを導入し、部門横断での即時データ生成を実現した事例。実データの露出をゼロにしつつ、承認サイクルを数か月から毎日・即時へと短縮。データ漏洩時のレコードあたりコスト（最大6ドル）のリスクも解消。",
+  "value_proposition": "データアクセス承認に数か月かかっていた状態から、即時の合成データ生成を実現。全部門で実データ露出ゼロを達成し、データ漏洩リスクに伴うコスト（レコードあたり最大6ドル）を解消。セキュリティとスピードを同時に改善。",
+  "synthetic_generation_method": "Betterdata社のプログラマティック合成データ生成プラットフォームを使用。完全オンプレミスで稼働し、銀行の各部門が必要に応じて即座に合成データを生成。",
+  "safety_evaluation_method": "完全オンプレミス環境で稼働し、実データが銀行の境界外に流出するリスクをゼロに。全部門で実データの露出なしに分析・テストを実施可能。",
+  "utility_evaluation_method": "各部門のデータ活用ニーズに対し、合成データが分析・テスト目的に十分な品質を持つことを運用で確認。",
+  "tags": [
+    "オンプレミス",
+    "即時生成",
+    "データ民主化",
+    "Betterdata",
+    "PETs"
+  ],
+  "sources": [
+    {
+      "source_type": "web",
+      "title": "Betterdata: Tier 1 Asian Bank",
+      "url": "https://www.betterdata.ai/case-study/tier-1-asian-bank",
+      "note": "Betterdataによる大手アジア銀行事例紹介"
+    }
+  ],
+  "figures": [
+    {
+      "type": "data_flow",
+      "title": "部門横断の即時合成データ生成フロー",
+      "data": {
+        "nodes": [
+          { "id": "s1", "label": "銀行の各部門のデータ", "category": "source" },
+          { "id": "s2", "label": "データ利用承認に数か月・漏洩リスク（6ドル/件）", "category": "constraint" },
+          { "id": "p1", "label": "Betterdataでオンプレミス即時合成データ生成", "category": "process" },
+          { "id": "a1", "label": "全部門でのデータ分析・テストに活用", "category": "application" },
+          { "id": "a2", "label": "実データ露出ゼロ・承認を即時化", "category": "outcome" }
+        ],
+        "edges": []
+      },
+      "note": ""
+    }
+  ],
+  "status": "draft",
+  "created_at": "2026-03-06T00:00:00+09:00",
+  "updated_at": "2026-03-06T00:00:00+09:00"
+}

--- a/public/cases/rpt-0011/case.json
+++ b/public/cases/rpt-0011/case.json
@@ -1,0 +1,53 @@
+{
+  "id": "rpt-0011",
+  "title": "5,500万行の国勢調査・死亡登録連結データの合成化",
+  "region": "国外",
+  "domain": "公共",
+  "domain_sub": "統計",
+  "organization": "ONS (英国国家統計局) / Alan Turing Institute",
+  "usecase_category": [
+    "外部分析者活用",
+    "R&D"
+  ],
+  "summary": "英国国家統計局（ONS）とアラン・チューリング研究所が共同で、2011年国勢調査と死亡登録を連結した約5,500万行・60列の機密データセットを差分プライバシーの枠組みの下で合成化した事例。大規模かつ連結データの合成化の代表的な取り組み。",
+  "value_proposition": "通常は厳格なアクセス制限のある機密連結データを、差分プライバシーを適用した合成データとして広く研究者に提供。性別・民族別の平均余命分析など、既存の公表済み分析結果を合成データでも再現できることを実証。",
+  "synthetic_generation_method": "最大全域木（MST）アルゴリズムを使用した3段階パイプライン: (1) 保持する相互作用の選択、(2) ノイズを加えた周辺分布の測定、(3) Private-PGMによるデータ生成。250万行ずつのバッチ処理でスケーラビリティを確保。国勢調査のみのレコードと死亡登録連結レコードを分離して合成。",
+  "safety_evaluation_method": "差分プライバシーを適用（Renyiパラメータ ε=1, δ=10^-8）。ONSの既存の最小カウント閾値（σ≧10）と整合させ、形式的なDP保証と組織の既存リスク基準を橋渡し。",
+  "utility_evaluation_method": "一般的有用性: 単変量忠実度（カバレッジ・類似度、多くの列で0.95超）、二変量忠実度（ペア相関）、識別性スコア（SPECKSメソッド、約0.8）。特定有用性: 性別・民族別の平均余命分析の公表済み結果を再現。世帯階層や併存疾患構造では課題も報告。",
+  "tags": [
+    "差分プライバシー",
+    "国勢調査",
+    "大規模データ",
+    "Private-PGM",
+    "ONS",
+    "PETs"
+  ],
+  "sources": [
+    {
+      "source_type": "web",
+      "title": "ONS Data Science Campus: Synthesising the linked 2011 Census and deaths dataset",
+      "url": "https://datasciencecampus.ons.gov.uk/synthesising-the-linked-2011-census-and-deaths-dataset-while-preserving-its-confidentiality/",
+      "note": "ONS Data Science Campusによる詳細レポート"
+    }
+  ],
+  "figures": [
+    {
+      "type": "data_flow",
+      "title": "大規模連結データの合成化フロー",
+      "data": {
+        "nodes": [
+          { "id": "s1", "label": "2011年国勢調査＋死亡登録連結データ（5,500万行・60列）", "category": "source" },
+          { "id": "s2", "label": "機密データへの厳格なアクセス制限", "category": "constraint" },
+          { "id": "p1", "label": "MSTアルゴリズム＋差分プライバシーで合成データを生成", "category": "process" },
+          { "id": "a1", "label": "研究者への安全なデータ提供", "category": "application" },
+          { "id": "a2", "label": "平均余命分析の再現を実証・単変量忠実度0.95超", "category": "outcome" }
+        ],
+        "edges": []
+      },
+      "note": ""
+    }
+  ],
+  "status": "draft",
+  "created_at": "2026-03-06T00:00:00+09:00",
+  "updated_at": "2026-03-06T00:00:00+09:00"
+}

--- a/public/cases/rpt-0012/case.json
+++ b/public/cases/rpt-0012/case.json
@@ -1,0 +1,52 @@
+{
+  "id": "rpt-0012",
+  "title": "Census 2021パイプラインテスト用の合成国勢調査データ生成",
+  "region": "国外",
+  "domain": "公共",
+  "domain_sub": "統計",
+  "organization": "ONS Data Science Campus",
+  "usecase_category": [
+    "フィージビリティ検証"
+  ],
+  "summary": "英国国家統計局（ONS）のData Science Campusが、Census 2021本番前に処理パイプラインのテスト用として合成国勢調査データを生成した事例。差分プライバシーを適用し、どの統計量を合成に使用するかをデータ所有者が制御できる仕組みを構築。統合データサービス（IDS）のデモ環境としても活用。",
+  "value_proposition": "本番の国勢調査データを使わずに処理パイプラインの事前検証が可能に。研究者のオンボーディング支援、ユーザートレーニング、手法テストなど、実データを使えない段階での多様な用途に合成データを活用。",
+  "synthetic_generation_method": "NIST 2018 Differential Privacy Synthetic Data Challengeの受賞手法を応用。差分プライバシーを適用し、データ所有者が合成に使用する統計量を選択できる仕組みを構築。データサイエンティストと非技術者の共同意思決定プロセスを導入。",
+  "safety_evaluation_method": "差分プライバシーによる定量的なプライバシーリスク管理。ONSのデータ保護担当者と開示管理専門家との協議を実施。Statistics and Registration Service Act 2007、UK GDPR、Data Protection Act 2018への準拠を検証。",
+  "utility_evaluation_method": "統計手法ライブラリ（Statistical Methods Library）を用いた機能テストを実施。IDS上での研究者オンボーディング、トレーニング、プラットフォーム改善に活用し、実務的な有用性を確認。",
+  "tags": [
+    "国勢調査",
+    "パイプラインテスト",
+    "差分プライバシー",
+    "IDS",
+    "ONS",
+    "PETs"
+  ],
+  "sources": [
+    {
+      "source_type": "web",
+      "title": "ONS Data Science Campus: Enabling Data Access through Privacy Preserving Synthetic Data",
+      "url": "https://datasciencecampus.ons.gov.uk/enabling-data-access-through-privacy-preserving-synthetic-data/",
+      "note": "ONS Data Science Campusによる合成データ活用レポート"
+    }
+  ],
+  "figures": [
+    {
+      "type": "data_flow",
+      "title": "Census 2021テスト用合成データ生成フロー",
+      "data": {
+        "nodes": [
+          { "id": "s1", "label": "国勢調査データ（連結・機密）", "category": "source" },
+          { "id": "s2", "label": "本番前のテスト環境に実データは使用不可", "category": "constraint" },
+          { "id": "p1", "label": "差分プライバシー適用の合成データを生成（NIST手法応用）", "category": "process" },
+          { "id": "a1", "label": "処理パイプラインテスト・IDS研究者オンボーディング", "category": "application" },
+          { "id": "a2", "label": "本番前に安全にパイプライン検証を完了", "category": "outcome" }
+        ],
+        "edges": []
+      },
+      "note": ""
+    }
+  ],
+  "status": "draft",
+  "created_at": "2026-03-06T00:00:00+09:00",
+  "updated_at": "2026-03-06T00:00:00+09:00"
+}

--- a/public/cases/rpt-0013/case.json
+++ b/public/cases/rpt-0013/case.json
@@ -1,0 +1,50 @@
+{
+  "id": "rpt-0013",
+  "title": "公共郵便事業における合成データによるデータサイロ解消",
+  "region": "国外",
+  "domain": "公共",
+  "organization": "Swiss Post / MOSTLY AI",
+  "usecase_category": [
+    "組織内データ共有"
+  ],
+  "summary": "スイスの国営郵便事業Swiss Postが、MOSTLY AI社の合成データプラットフォーム（AWS基盤）を導入し、センシティブデータを安全に活用しながらデータサイロの解消を実現した事例。公共性の高い組織として厳格なプライバシー・データ保護基準を維持しつつ、モデルの説明可能性や性能向上に合成データを活用。",
+  "value_proposition": "公共性の高い組織で蓄積していたデータサイロを合成データにより安全に解消。従来の匿名化手法では困難だった組織横断のデータ連携を実現し、モデルの説明可能性と性能を向上。",
+  "synthetic_generation_method": "MOSTLY AI社の合成データ生成プラットフォームを使用。AWS基盤で稼働し、センシティブなデータの統計的特性を保持した合成データを生成。",
+  "safety_evaluation_method": "公共事業に求められる厳格なプライバシー・データ保護基準を維持。従来の匿名化手法ではなく合成データによるアプローチで、データの有用性と安全性を両立。",
+  "utility_evaluation_method": "合成データを用いたモデルの説明可能性と性能向上の効果を検証。組織横断のデータ活用による業務改善効果を確認。",
+  "tags": [
+    "データサイロ",
+    "説明可能性",
+    "AWS",
+    "MOSTLY AI",
+    "PETs"
+  ],
+  "sources": [
+    {
+      "source_type": "web",
+      "title": "Swiss Post x MOSTLY AI: Synthetic Data Innovation on AWS",
+      "url": "https://mostly.ai/video/swiss-post-x-mostly-ai-synthetic-data-innovation-on-aws",
+      "note": "MOSTLY AIによるSwiss Post事例紹介動画"
+    }
+  ],
+  "figures": [
+    {
+      "type": "data_flow",
+      "title": "Swiss Postにおけるデータサイロ解消フロー",
+      "data": {
+        "nodes": [
+          { "id": "s1", "label": "Swiss Postの各部門の業務データ", "category": "source" },
+          { "id": "s2", "label": "データサイロと厳格なプライバシー基準", "category": "constraint" },
+          { "id": "p1", "label": "MOSTLY AIで合成データを生成（AWS基盤）", "category": "process" },
+          { "id": "a1", "label": "組織横断のデータ活用・モデル開発", "category": "application" },
+          { "id": "a2", "label": "データサイロ解消とモデル性能向上を両立", "category": "outcome" }
+        ],
+        "edges": []
+      },
+      "note": ""
+    }
+  ],
+  "status": "draft",
+  "created_at": "2026-03-06T00:00:00+09:00",
+  "updated_at": "2026-03-06T00:00:00+09:00"
+}

--- a/public/cases/rpt-0014/case.json
+++ b/public/cases/rpt-0014/case.json
@@ -1,0 +1,52 @@
+{
+  "id": "rpt-0014",
+  "title": "サイバー防御訓練・異常検知向けプライバシー保護データサンドボックス",
+  "region": "国外",
+  "domain": "公共",
+  "domain_sub": "セキュリティ",
+  "organization": "U.S. Department of Homeland Security / Betterdata",
+  "usecase_category": [
+    "フィージビリティ検証"
+  ],
+  "summary": "米国国土安全保障省（DHS）が、プライバシー・セキュリティ上の制約で実データ共有ができない環境において、Betterdata社のTFMベースの合成データ技術を用いてサイバー防御訓練と異常検知向けのデータサンドボックスを構築した事例。",
+  "value_proposition": "機密データを一切外部に出さずに、リアルなサイバー防御訓練と異常検知の演習環境を構築。訓練の加速と実践的なシミュレーションを、セキュリティリスクなしに実現。",
+  "synthetic_generation_method": "Betterdata社のTFM（Tabular Foundation Model）ベースのプライバシー保護合成データ生成技術を使用。サイバーセキュリティおよびネットワークデータの合成データを生成。",
+  "safety_evaluation_method": "合成データにより、機密性の高い政府データの一切の露出なしに訓練・シミュレーションを実施。実データへのアクセスを完全に排除した環境を構築。",
+  "utility_evaluation_method": "サイバー防御訓練と異常検知の実効性を合成データ環境で検証し、訓練目的に十分な品質であることを確認。",
+  "tags": [
+    "サイバーセキュリティ",
+    "異常検知",
+    "訓練データ",
+    "TFM",
+    "Betterdata",
+    "PETs"
+  ],
+  "sources": [
+    {
+      "source_type": "web",
+      "title": "Betterdata: U.S. Department of Homeland Security",
+      "url": "https://www.betterdata.ai/case-study/u-s-department-of-homeland-security",
+      "note": "BetterdataによるDHS事例紹介"
+    }
+  ],
+  "figures": [
+    {
+      "type": "data_flow",
+      "title": "サイバー防御訓練向け合成データ活用フロー",
+      "data": {
+        "nodes": [
+          { "id": "s1", "label": "DHSのサイバーセキュリティ・ネットワークデータ", "category": "source" },
+          { "id": "s2", "label": "機密データのセキュリティ制約による共有不可", "category": "constraint" },
+          { "id": "p1", "label": "TFMベースで合成サイバーデータを生成", "category": "process" },
+          { "id": "a1", "label": "サイバー防御訓練・異常検知シミュレーション", "category": "application" },
+          { "id": "a2", "label": "実データ露出ゼロで実践的な訓練環境を構築", "category": "outcome" }
+        ],
+        "edges": []
+      },
+      "note": ""
+    }
+  ],
+  "status": "draft",
+  "created_at": "2026-03-06T00:00:00+09:00",
+  "updated_at": "2026-03-06T00:00:00+09:00"
+}

--- a/public/cases/rpt-0015/case.json
+++ b/public/cases/rpt-0015/case.json
@@ -1,0 +1,53 @@
+{
+  "id": "rpt-0015",
+  "title": "スマートビルにおける合成データ活用による同意要件の簡素化",
+  "region": "国外",
+  "domain": "通信",
+  "domain_sub": "建設/IoT",
+  "organization": "鹿島建設 / Betterdata",
+  "usecase_category": [
+    "組織内データ共有"
+  ],
+  "summary": "鹿島建設がスマートビル領域において、建物利用者の個別同意取得が重くデータ活用が非効率だった課題に対し、Betterdata社の合成データ基盤を導入した事例。個別同意を不要化し、運用コストを60%削減しながら規制準拠を維持。",
+  "value_proposition": "スマートビルの利用者データについて個別の同意取得を不要とし、運用コストを60%削減。規制準拠を維持しつつ、データ活用のスピードと効率性を大幅に改善。",
+  "synthetic_generation_method": "Betterdata社のセルフサービス型合成データ生成プラットフォームを使用。スマートビルのセンサー・利用者データの統計的特性を保持した合成データを生成。",
+  "safety_evaluation_method": "合成データは実在の利用者情報を含まないため、個別の同意取得が不要に。規制準拠を維持した上でデータ活用が可能な環境を構築。",
+  "utility_evaluation_method": "合成データを用いたスマートビル運用の分析・最適化の精度を検証し、運用コスト60%削減の効果を計測。",
+  "tags": [
+    "スマートビル",
+    "IoT",
+    "同意不要化",
+    "60%コスト削減",
+    "鹿島建設",
+    "Betterdata",
+    "PETs"
+  ],
+  "sources": [
+    {
+      "source_type": "web",
+      "title": "Betterdata: Kajima Corporation",
+      "url": "https://www.betterdata.ai/case-study/kajima-corporation",
+      "note": "Betterdataによる鹿島建設事例紹介"
+    }
+  ],
+  "figures": [
+    {
+      "type": "data_flow",
+      "title": "スマートビルにおける合成データ活用フロー",
+      "data": {
+        "nodes": [
+          { "id": "s1", "label": "スマートビルのセンサー・利用者データ", "category": "source" },
+          { "id": "s2", "label": "利用者ごとの個別同意取得が重く非効率", "category": "constraint" },
+          { "id": "p1", "label": "Betterdataで合成データを生成", "category": "process" },
+          { "id": "a1", "label": "ビル運用の分析・最適化に活用", "category": "application" },
+          { "id": "a2", "label": "個別同意不要化・運用コスト60%削減を実現", "category": "outcome" }
+        ],
+        "edges": []
+      },
+      "note": ""
+    }
+  ],
+  "status": "draft",
+  "created_at": "2026-03-06T00:00:00+09:00",
+  "updated_at": "2026-03-06T00:00:00+09:00"
+}

--- a/public/cases/rpt-0016/case.json
+++ b/public/cases/rpt-0016/case.json
@@ -1,0 +1,52 @@
+{
+  "id": "rpt-0016",
+  "title": "テレメトリパイプラインの20倍規模シミュレーションによるQA効率化",
+  "region": "国外",
+  "domain": "通信",
+  "domain_sub": "IT",
+  "organization": "Fortune 500 データストレージ企業 / Betterdata",
+  "usecase_category": [
+    "フィージビリティ検証"
+  ],
+  "summary": "Fortune 500に名を連ねるデータストレージ企業が、本番データの利用が困難なQA環境において、Betterdata社の合成データ技術を活用し、テレメトリパイプラインの20倍規模シミュレーションとQA準備時間40%削減を実現した事例。",
+  "value_proposition": "本番データを使わずに、実環境の20倍のスケールでテレメトリパイプラインをシミュレーション可能に。QA準備時間を40%削減し、より高速かつ信頼性の高いシステムテストを実現。",
+  "synthetic_generation_method": "Betterdata社の合成データ生成プラットフォームを使用。サブスクリプションシステムのテレメトリデータを模した合成データを生成し、実環境の20倍規模のシミュレーションに使用。",
+  "safety_evaluation_method": "合成データの使用により、本番の顧客テレメトリデータをQA環境に持ち込むリスクを解消。",
+  "utility_evaluation_method": "QAスループットとシミュレーション規模で評価。20倍規模のシミュレーション実行とQA準備時間40%削減を実測。",
+  "tags": [
+    "QA",
+    "テレメトリ",
+    "大規模テスト",
+    "40%時間削減",
+    "Betterdata",
+    "PETs"
+  ],
+  "sources": [
+    {
+      "source_type": "web",
+      "title": "Betterdata: Fortune 500 Data Storage Provider",
+      "url": "https://www.betterdata.ai/case-study/fortune-500-data-storage-provider",
+      "note": "BetterdataによるFortune 500企業事例紹介"
+    }
+  ],
+  "figures": [
+    {
+      "type": "data_flow",
+      "title": "QA用合成テレメトリデータ活用フロー",
+      "data": {
+        "nodes": [
+          { "id": "s1", "label": "サブスクリプションシステムのテレメトリデータ", "category": "source" },
+          { "id": "s2", "label": "本番データをQA環境で使用困難", "category": "constraint" },
+          { "id": "p1", "label": "Betterdataで合成テレメトリデータを生成", "category": "process" },
+          { "id": "a1", "label": "20倍規模のパイプラインシミュレーション・QA", "category": "application" },
+          { "id": "a2", "label": "QA準備時間40%削減・信頼性向上", "category": "outcome" }
+        ],
+        "edges": []
+      },
+      "note": ""
+    }
+  ],
+  "status": "draft",
+  "created_at": "2026-03-06T00:00:00+09:00",
+  "updated_at": "2026-03-06T00:00:00+09:00"
+}

--- a/public/cases/rpt-0017/case.json
+++ b/public/cases/rpt-0017/case.json
@@ -1,0 +1,52 @@
+{
+  "id": "rpt-0017",
+  "title": "欧州高級ブランドにおける合成データによるVIPコンバージョン改善",
+  "region": "国外",
+  "domain": "金融",
+  "domain_sub": "小売/マーケティング",
+  "organization": "欧州高級ブランド / Betterdata",
+  "usecase_category": [
+    "R&D"
+  ],
+  "summary": "欧州の著名な高級ブランドが、顧客データが疎でパーソナライズが困難な状況において、Betterdata社の合成データ拡張技術を用いてプロペンシティモデリングを補強し、VIPコンバージョンを約5%改善した事例。データ不足の課題を合成データで解決したマーケティング活用例。",
+  "value_proposition": "実在の顧客データが少なくパーソナライズが困難だった課題を、合成データによるデータ拡張で解決。VIPコンバージョンを約5%改善し、高価値顧客とのエンゲージメントを強化。",
+  "synthetic_generation_method": "Betterdata社の合成データ拡張型プロペンシティモデリング技術を使用。疎な実データセットを合成レコードで補強し、モデルの学習データ量を増加。",
+  "safety_evaluation_method": "合成データ生成プロセスにおいて新たな実在の個人情報は作成されず、既存の顧客データのプライバシーを維持。",
+  "utility_evaluation_method": "VIPコンバージョン率の改善（約5%向上）というビジネス指標で成果を計測。",
+  "tags": [
+    "マーケティング",
+    "データ拡張",
+    "VIP",
+    "プロペンシティモデル",
+    "Betterdata",
+    "PETs"
+  ],
+  "sources": [
+    {
+      "source_type": "web",
+      "title": "Betterdata: Iconic European Luxury Brand",
+      "url": "https://www.betterdata.ai/case-study/iconic-european-luxury-brand",
+      "note": "Betterdataによる欧州高級ブランド事例紹介"
+    }
+  ],
+  "figures": [
+    {
+      "type": "data_flow",
+      "title": "合成データ拡張によるVIPコンバージョン改善フロー",
+      "data": {
+        "nodes": [
+          { "id": "s1", "label": "高級ブランドの顧客行動・取引データ（疎）", "category": "source" },
+          { "id": "s2", "label": "顧客データが疎でパーソナライズ困難", "category": "constraint" },
+          { "id": "p1", "label": "Betterdataで合成データを拡張生成しモデルを補強", "category": "process" },
+          { "id": "a1", "label": "VIP向けプロペンシティモデリング", "category": "application" },
+          { "id": "a2", "label": "VIPコンバージョン約5%改善", "category": "outcome" }
+        ],
+        "edges": []
+      },
+      "note": ""
+    }
+  ],
+  "status": "draft",
+  "created_at": "2026-03-06T00:00:00+09:00",
+  "updated_at": "2026-03-06T00:00:00+09:00"
+}


### PR DESCRIPTION
## Summary
- `docs/20260306_case_report.md` のレポートから17件の個別事例をcase.jsonとして追加
- レポート内の横断レポート（3件）、既存事例との重複（4件: fpf-0002/0004/0005/0006）、想定事例（1件）はスキップ
- 各事例のソースURLから詳細情報を取得し、生成手法・安全性評価・有用性評価を充実化

## 追加事例一覧（17件）

### 医療（8件）
| ID | タイトル | 組織 |
|---|---|---|
| rpt-0001 | 肺がん死亡リスク予測モデル | HRA / ICO |
| rpt-0002 | SynthVAEによる模擬患者データ | NHS England |
| rpt-0003 | 退役軍人医療機関の合成データ基盤 | VHA / MDClone |
| rpt-0004 | 合成データ精度の3パイロット検証 | Washington Univ / MDClone |
| rpt-0005 | 州全体レベルの合成EHR | SA Health / Gretel |
| rpt-0006 | ゲノム研究向け合成データ | Illumina / Gretel |
| rpt-0007 | 1,600万件の合成患者記録でML学習 | 大手医療機関 / Gretel |
| rpt-0008 | 150万件合成データサンドボックス | Humana / MOSTLY AI |

### 金融（3件）
| ID | タイトル | 組織 |
|---|---|---|
| rpt-0009 | GDPR準拠の保険AIモデル（99%精度） | BeRebel / Aindo |
| rpt-0010 | 部門横断の即時合成データ生成基盤 | Tier 1 Asian Bank / Betterdata |
| rpt-0017 | VIPコンバージョン5%改善 | 欧州高級ブランド / Betterdata |

### 公共（4件）
| ID | タイトル | 組織 |
|---|---|---|
| rpt-0011 | 5,500万行の国勢調査連結データ合成化 | ONS / Alan Turing |
| rpt-0012 | Census 2021パイプラインテスト用合成データ | ONS Data Science Campus |
| rpt-0013 | データサイロ解消 | Swiss Post / MOSTLY AI |
| rpt-0014 | サイバー防御訓練用サンドボックス | DHS / Betterdata |

### 通信・IT（2件）
| ID | タイトル | 組織 |
|---|---|---|
| rpt-0015 | スマートビルの同意要件簡素化（60%コスト削減） | 鹿島建設 / Betterdata |
| rpt-0016 | テレメトリQA 20倍規模シミュレーション | Fortune 500 / Betterdata |

## Test plan
- [x] `npx tsx scripts/validate-cases.ts` — 36件すべてバリデーション通過
- [ ] ブラウザで事例一覧・詳細表示を確認
- [ ] フィルタで新規事例が正しく絞り込めることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)