### PR TITLE
feat: PETs事例拡充・タイトル変更・統計ページ・UI改善

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>syntheticdata-usecase-catalog-tmp</title>
+    <title>プライバシー強化技術 活用事例カタログ</title>
   </head>
   <body>
     <div id="root"></div>

--- a/src/__tests__/AboutPage.test.tsx
+++ b/src/__tests__/AboutPage.test.tsx
@@ -9,7 +9,7 @@ describe('AboutPage', () => {
         <AboutPage />
       </MemoryRouter>,
     )
-    expect(screen.getByText('合成データ活用事例カタログ')).toBeInTheDocument()
+    expect(screen.getByText('プライバシー強化技術 活用事例カタログ')).toBeInTheDocument()
   })
 
   it('免責事項が表示される', () => {

--- a/src/__tests__/Header.test.tsx
+++ b/src/__tests__/Header.test.tsx
@@ -13,7 +13,7 @@ function renderHeader() {
 describe('Header', () => {
   it('アプリ名が表示される', () => {
     renderHeader()
-    expect(screen.getByText('合成データ ユースケースカタログ')).toBeInTheDocument()
+    expect(screen.getByText('プライバシー強化技術 活用事例カタログ')).toBeInTheDocument()
   })
 
   it('一覧リンクが存在する', () => {

--- a/src/components/case-list/CaseCard.tsx
+++ b/src/components/case-list/CaseCard.tsx
@@ -1,6 +1,6 @@
 import { Link } from 'react-router-dom'
 import type { Case } from '../../types'
-import { DOMAIN_COLORS, REGION_COLORS, REVIEW_STATUS_COLORS } from '../../constants/styles'
+import { DOMAIN_COLORS, REGION_COLORS, REVIEW_STATUS_COLORS, TECHNOLOGY_CATEGORY_COLORS } from '../../constants/styles'
 import { TECHNOLOGY_CATEGORY_LABELS, REVIEW_STATUS_LABELS } from '../../constants/categories'
 
 interface CaseCardProps {
@@ -27,7 +27,7 @@ export default function CaseCard({ caseItem }: CaseCardProps) {
           </span>
         )}
         {caseItem.technology_category?.map((tech) => (
-          <span key={tech} className="text-[10px] font-medium px-1.5 py-0.5 rounded-full bg-slate-100 text-slate-600">
+          <span key={tech} className={`text-[10px] font-medium px-1.5 py-0.5 rounded-full text-white ${TECHNOLOGY_CATEGORY_COLORS[tech] ?? 'bg-slate-400'}`}>
             {TECHNOLOGY_CATEGORY_LABELS[tech] ?? tech}
           </span>
         ))}

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -5,7 +5,7 @@ export default function Header() {
     <header className="bg-blue-600 text-white shadow-md">
       <div className="max-w-7xl mx-auto px-4 py-3 flex items-center justify-between">
         <Link to="/" className="text-xl font-bold hover:opacity-90">
-          合成データ ユースケースカタログ
+          プライバシー強化技術 活用事例カタログ
         </Link>
         <nav className="flex gap-4">
           <Link to="/" className="hover:underline">一覧</Link>

--- a/src/constants/categories.ts
+++ b/src/constants/categories.ts
@@ -1,6 +1,6 @@
 export const REGION_OPTIONS = ['国内', '国外'] as const
 
-export const DOMAIN_OPTIONS = ['金融', '医療', '公共', '通信'] as const
+export const DOMAIN_OPTIONS = ['金融', '医療', '公共', '通信', 'モビリティ', 'IT', 'エネルギー', '小売'] as const
 
 export const USECASE_CATEGORY_OPTIONS = [
   '組織内データ共有',
@@ -9,6 +9,7 @@ export const USECASE_CATEGORY_OPTIONS = [
   'R&D',
   'データ販売',
   'フィージビリティ検証',
+  '公的利用',
 ] as const
 
 export const TECHNOLOGY_CATEGORY_OPTIONS = [

--- a/src/constants/styles.ts
+++ b/src/constants/styles.ts
@@ -4,6 +4,10 @@ export const DOMAIN_COLORS = {
   '医療': { bg: 'bg-rose-500', border: 'border-l-rose-500', badge: 'bg-rose-50 text-rose-700 ring-1 ring-rose-200' },
   '公共': { bg: 'bg-indigo-500', border: 'border-l-indigo-500', badge: 'bg-indigo-50 text-indigo-700 ring-1 ring-indigo-200' },
   '通信': { bg: 'bg-cyan-500', border: 'border-l-cyan-500', badge: 'bg-cyan-50 text-cyan-700 ring-1 ring-cyan-200' },
+  'モビリティ': { bg: 'bg-blue-500', border: 'border-l-blue-500', badge: 'bg-blue-50 text-blue-700 ring-1 ring-blue-200' },
+  'IT': { bg: 'bg-purple-500', border: 'border-l-purple-500', badge: 'bg-purple-50 text-purple-700 ring-1 ring-purple-200' },
+  'エネルギー': { bg: 'bg-amber-500', border: 'border-l-amber-500', badge: 'bg-amber-50 text-amber-700 ring-1 ring-amber-200' },
+  '小売': { bg: 'bg-orange-500', border: 'border-l-orange-500', badge: 'bg-orange-50 text-orange-700 ring-1 ring-orange-200' },
 } as const
 
 /** Region ごとの色定義 */
@@ -20,6 +24,7 @@ export const CATEGORY_COLORS: Record<string, string> = {
   'R&D': 'bg-sky-500',
   'データ販売': 'bg-teal-500',
   'フィージビリティ検証': 'bg-orange-500',
+  '公的利用': 'bg-indigo-500',
 }
 
 /** 技術カテゴリごとの色定義 */

--- a/src/pages/AboutPage.tsx
+++ b/src/pages/AboutPage.tsx
@@ -1,13 +1,13 @@
 export default function AboutPage() {
   return (
     <div className="max-w-2xl mx-auto space-y-8">
-      <h1 className="text-2xl font-bold">合成データ活用事例カタログ</h1>
+      <h1 className="text-2xl font-bold">プライバシー強化技術 活用事例カタログ</h1>
 
       <section className="space-y-2">
         <h2 className="text-lg font-semibold">概要</h2>
         <p className="text-gray-700">
-          本カタログは、合成データ（Synthetic Data）の活用事例を収集・整理し、検索・閲覧できるWebカタログです。
-          国内外の多様な分野における合成データの活用方法、安全性評価、有用性評価の情報を提供します。
+          本カタログは、プライバシー強化技術（PETs: Privacy Enhancing Technologies）の活用事例を収集・整理し、検索・閲覧できるWebカタログです。
+          合成データ、差分プライバシー、匿名化、連合学習、秘密計算など、国内外の多様な分野における活用方法と評価情報を提供します。
         </p>
       </section>
 


### PR DESCRIPTION
## Summary
- カタログタイトルを「プライバシー強化技術 活用事例カタログ」に変更
- 統計ページ(/stats)を新規追加（KPI、技術カテゴリ別推移グラフ、各種横棒グラフ）
- SummaryPanelから技術カテゴリStackedBarを削除（複数PETs組み合わせ時の過カウント対策）
- 匿名加工情報・仮名加工情報13件の事例を追加（anon-0001〜0013）
- 部分合成データ6件の事例を追加（psd-0001〜0006）
- 連合学習5件の事例を追加（fl-0001〜0005）
- DOMAIN_COLORSに新ドメイン4種追加（モビリティ, IT, エネルギー, 小売）
- USECASE_CATEGORY_OPTIONSに「公的利用」追加
- CaseCardの技術カテゴリバッジをカテゴリ別に色分け表示
- AboutPageの概要文をPETs全般の説明に更新

## Test plan
- [x] 全678テストパス
- [x] TypeScript型チェック通過
- [x] ビルド成功
- [ ] ブラウザ確認: 新事例（匿名化・連合学習等）が一覧に表示される
- [ ] ブラウザ確認: 技術カテゴリバッジが色分け表示される
- [ ] ブラウザ確認: 新ドメイン（モビリティ等）が色付きで表示される
- [ ] ブラウザ確認: 統計ページが正常に表示される
- [ ] ブラウザ確認: タイトルが「プライバシー強化技術 活用事例カタログ」に変わっている

🤖 Generated with [Claude Code](https://claude.com/claude-code)