### PR TITLE
feat: 全41事例に概要フロー図を追加

### DIFF
--- a/public/cases/anon-0001/case.json
+++ b/public/cases/anon-0001/case.json
@@ -30,7 +30,23 @@
       "url": "https://www.nissan.co.jp/CONNECT/MEMBER/RULES/privacy.html"
     }
   ],
-  "figures": [],
+  "figures": [
+    {
+      "type": "data_flow",
+      "title": "概要フロー",
+      "data": {
+        "nodes": [
+          {"id": "s1", "label": "NissanConnect車両の位置・時刻情報", "category": "source"},
+          {"id": "s2", "label": "個人の移動履歴はプライバシー情報", "category": "constraint"},
+          {"id": "p1", "label": "位置・時刻情報を匿名加工し統計化", "category": "process"},
+          {"id": "a1", "label": "VICSへ交通情報として提供", "category": "application"},
+          {"id": "a2", "label": "渋滞回避ルートで運転時間短縮", "category": "outcome"}
+        ],
+        "edges": []
+      },
+      "note": ""
+    }
+  ],
   "status": "seed",
   "created_at": "2026-03-07T00:00:00+09:00",
   "updated_at": "2026-03-08T00:00:00+09:00"

--- a/public/cases/anon-0003/case.json
+++ b/public/cases/anon-0003/case.json
@@ -28,7 +28,23 @@
       "url": "https://www.med.shimadzu.co.jp/attention/privacy_anonymous.html"
     }
   ],
-  "figures": [],
+  "figures": [
+    {
+      "type": "data_flow",
+      "title": "概要フロー",
+      "data": {
+        "nodes": [
+          {"id": "s1", "label": "医療機関の臨床データ", "category": "source"},
+          {"id": "s2", "label": "患者個人情報の保護が必要", "category": "constraint"},
+          {"id": "p1", "label": "臨床データを匿名加工情報に変換", "category": "process"},
+          {"id": "a1", "label": "医療機器の研究開発・改良に活用", "category": "application"},
+          {"id": "a2", "label": "プライバシー保護と機器品質向上を両立", "category": "outcome"}
+        ],
+        "edges": []
+      },
+      "note": ""
+    }
+  ],
   "status": "seed",
   "created_at": "2026-03-07T00:00:00+09:00",
   "updated_at": "2026-03-07T00:00:00+09:00"

--- a/public/cases/anon-0004/case.json
+++ b/public/cases/anon-0004/case.json
@@ -28,7 +28,23 @@
       "url": "https://www.msdkenpo.or.jp/member/info/files/privacy-policy_h.pdf"
     }
   ],
-  "figures": [],
+  "figures": [
+    {
+      "type": "data_flow",
+      "title": "概要フロー",
+      "data": {
+        "nodes": [
+          {"id": "s1", "label": "健診・レセプト・保健事業データ", "category": "source"},
+          {"id": "s2", "label": "被保険者の個人情報保護が必要", "category": "constraint"},
+          {"id": "p1", "label": "各種データを匿名加工情報に変換", "category": "process"},
+          {"id": "a1", "label": "他組合比較による保健事業評価", "category": "application"},
+          {"id": "a2", "label": "データに基づく保健事業の改善", "category": "outcome"}
+        ],
+        "edges": []
+      },
+      "note": ""
+    }
+  ],
   "status": "seed",
   "created_at": "2026-03-07T00:00:00+09:00",
   "updated_at": "2026-03-07T00:00:00+09:00"

--- a/public/cases/anon-0005/case.json
+++ b/public/cases/anon-0005/case.json
@@ -33,7 +33,23 @@
       "url": "https://www.jipdec.or.jp/news/news/htpisq0000002w03-att/20220318_case_study_privacygovernance_research.pdf"
     }
   ],
-  "figures": [],
+  "figures": [
+    {
+      "type": "data_flow",
+      "title": "概要フロー",
+      "data": {
+        "nodes": [
+          {"id": "s1", "label": "JCBカード会員の属性・決済情報", "category": "source"},
+          {"id": "s2", "label": "個人の購買行動はプライバシー情報", "category": "constraint"},
+          {"id": "p1", "label": "決済情報を匿名加工し統計化", "category": "process"},
+          {"id": "a1", "label": "「JCB消費NOW」として一般公開", "category": "application"},
+          {"id": "a2", "label": "社会全体の消費動向把握に貢献", "category": "outcome"}
+        ],
+        "edges": []
+      },
+      "note": ""
+    }
+  ],
   "status": "seed",
   "created_at": "2026-03-07T00:00:00+09:00",
   "updated_at": "2026-03-07T00:00:00+09:00"

--- a/public/cases/anon-0006/case.json
+++ b/public/cases/anon-0006/case.json
@@ -28,7 +28,23 @@
       "url": "https://www.ppc.go.jp/files/pdf/tokumeikakoujireisyu.pdf"
     }
   ],
-  "figures": [],
+  "figures": [
+    {
+      "type": "data_flow",
+      "title": "概要フロー",
+      "data": {
+        "nodes": [
+          {"id": "s1", "label": "POS・決済・処方箋・レセプト等", "category": "source"},
+          {"id": "s2", "label": "多業種の個人情報保護が必要", "category": "constraint"},
+          {"id": "p1", "label": "各業種データを匿名加工情報に変換", "category": "process"},
+          {"id": "a1", "label": "公的事例集として利活用方法を整理", "category": "application"},
+          {"id": "a2", "label": "匿名加工の実務指針を社会に提供", "category": "outcome"}
+        ],
+        "edges": []
+      },
+      "note": ""
+    }
+  ],
   "status": "seed",
   "created_at": "2026-03-07T00:00:00+09:00",
   "updated_at": "2026-03-07T00:00:00+09:00"

--- a/public/cases/anon-0007/case.json
+++ b/public/cases/anon-0007/case.json
@@ -28,7 +28,23 @@
       "url": "https://www.ppc.go.jp/files/pdf/report_office_zirei2205.pdf"
     }
   ],
-  "figures": [],
+  "figures": [
+    {
+      "type": "data_flow",
+      "title": "概要フロー",
+      "data": {
+        "nodes": [
+          {"id": "s1", "label": "ICカード乗降履歴データ", "category": "source"},
+          {"id": "s2", "label": "個人の移動パターンはプライバシー情報", "category": "constraint"},
+          {"id": "p1", "label": "乗降履歴を匿名加工情報に変換", "category": "process"},
+          {"id": "a1", "label": "商圏分析・ターゲティング広告", "category": "application"},
+          {"id": "a2", "label": "人流データ活用によるビジネス創出", "category": "outcome"}
+        ],
+        "edges": []
+      },
+      "note": ""
+    }
+  ],
   "status": "seed",
   "created_at": "2026-03-07T00:00:00+09:00",
   "updated_at": "2026-03-07T00:00:00+09:00"

--- a/public/cases/anon-0008/case.json
+++ b/public/cases/anon-0008/case.json
@@ -34,7 +34,23 @@
       "url": "https://jpn.nec.com/press/202306/20230601_01.html"
     }
   ],
-  "figures": [],
+  "figures": [
+    {
+      "type": "data_flow",
+      "title": "概要フロー",
+      "data": {
+        "nodes": [
+          {"id": "s1", "label": "健康ポイントアプリのライフログ", "category": "source"},
+          {"id": "s2", "label": "個人の健康情報は高い保護が必要", "category": "constraint"},
+          {"id": "p1", "label": "個人情報を仮名加工情報に変換", "category": "process"},
+          {"id": "a1", "label": "健康行動変容AIの研究開発", "category": "application"},
+          {"id": "a2", "label": "健康寿命延伸・医療費適正化に貢献", "category": "outcome"}
+        ],
+        "edges": []
+      },
+      "note": ""
+    }
+  ],
   "status": "seed",
   "created_at": "2026-03-07T00:00:00+09:00",
   "updated_at": "2026-03-08T00:00:00+09:00"

--- a/public/cases/anon-0009/case.json
+++ b/public/cases/anon-0009/case.json
@@ -28,7 +28,23 @@
       "url": "https://www.smbc.co.jp/kojin/decile/kamei/"
     }
   ],
-  "figures": [],
+  "figures": [
+    {
+      "type": "data_flow",
+      "title": "概要フロー",
+      "data": {
+        "nodes": [
+          {"id": "s1", "label": "decileサービス利用者情報", "category": "source"},
+          {"id": "s2", "label": "顧客の属性情報は個人情報", "category": "constraint"},
+          {"id": "p1", "label": "利用者情報を仮名加工情報に変換", "category": "process"},
+          {"id": "a1", "label": "性別・住所・年齢等による分析", "category": "application"},
+          {"id": "a2", "label": "プロダクト改善の意思決定を支援", "category": "outcome"}
+        ],
+        "edges": []
+      },
+      "note": ""
+    }
+  ],
   "status": "seed",
   "created_at": "2026-03-07T00:00:00+09:00",
   "updated_at": "2026-03-07T00:00:00+09:00"

--- a/public/cases/anon-0010/case.json
+++ b/public/cases/anon-0010/case.json
@@ -28,7 +28,23 @@
       "url": "https://www.ono.co.jp/jpnw/privacy/index.html"
     }
   ],
-  "figures": [],
+  "figures": [
+    {
+      "type": "data_flow",
+      "title": "概要フロー",
+      "data": {
+        "nodes": [
+          {"id": "s1", "label": "患者の臨床・医療データ", "category": "source"},
+          {"id": "s2", "label": "個人情報保護法による利用制限", "category": "constraint"},
+          {"id": "p1", "label": "仮名加工情報として加工・管理", "category": "process"},
+          {"id": "a1", "label": "医薬品の研究開発・臨床試験に活用", "category": "application"},
+          {"id": "a2", "label": "プライバシー保護と研究開発を両立", "category": "outcome"}
+        ],
+        "edges": []
+      },
+      "note": ""
+    }
+  ],
   "status": "seed",
   "created_at": "2026-03-07T00:00:00+09:00",
   "updated_at": "2026-03-07T00:00:00+09:00"

--- a/public/cases/anon-0011/case.json
+++ b/public/cases/anon-0011/case.json
@@ -28,7 +28,23 @@
       "url": "https://www.irric.co.jp/pdf/privacy_policy/shared_use_public_declaration.pdf"
     }
   ],
-  "figures": [],
+  "figures": [
+    {
+      "type": "data_flow",
+      "title": "概要フロー",
+      "data": {
+        "nodes": [
+          {"id": "s1", "label": "グループ各社の顧客データ", "category": "source"},
+          {"id": "s2", "label": "個人データの社外共有に制約", "category": "constraint"},
+          {"id": "p1", "label": "仮名加工情報としてグループ内共同利用", "category": "process"},
+          {"id": "a1", "label": "商品・サービスの企画・開発に活用", "category": "application"},
+          {"id": "a2", "label": "グループ横断のデータ活用を実現", "category": "outcome"}
+        ],
+        "edges": []
+      },
+      "note": ""
+    }
+  ],
   "status": "seed",
   "created_at": "2026-03-07T00:00:00+09:00",
   "updated_at": "2026-03-07T00:00:00+09:00"

--- a/public/cases/anon-0012/case.json
+++ b/public/cases/anon-0012/case.json
@@ -27,7 +27,23 @@
       "url": "https://www.meiz.co.jp/tokumei/"
     }
   ],
-  "figures": [],
+  "figures": [
+    {
+      "type": "data_flow",
+      "title": "概要フロー",
+      "data": {
+        "nodes": [
+          {"id": "s1", "label": "業務データ・顧客データ", "category": "source"},
+          {"id": "s2", "label": "個人情報の社内利用に制約", "category": "constraint"},
+          {"id": "p1", "label": "仮名加工情報として社内活用", "category": "process"},
+          {"id": "a1", "label": "業務改善・新規サービス研究に活用", "category": "application"},
+          {"id": "a2", "label": "安全にデータ活用し業務効率化", "category": "outcome"}
+        ],
+        "edges": []
+      },
+      "note": ""
+    }
+  ],
   "status": "seed",
   "created_at": "2026-03-07T00:00:00+09:00",
   "updated_at": "2026-03-07T00:00:00+09:00"

--- a/public/cases/anon-0013/case.json
+++ b/public/cases/anon-0013/case.json
@@ -28,7 +28,23 @@
       "url": "https://www.energyline.co.jp/policy/kamei.html"
     }
   ],
-  "figures": [],
+  "figures": [
+    {
+      "type": "data_flow",
+      "title": "概要フロー",
+      "data": {
+        "nodes": [
+          {"id": "s1", "label": "サービス利用・運用データ", "category": "source"},
+          {"id": "s2", "label": "個人情報を含む分析に制約", "category": "constraint"},
+          {"id": "p1", "label": "仮名加工情報として加工・分析", "category": "process"},
+          {"id": "a1", "label": "運用保守分析・不正防止に活用", "category": "application"},
+          {"id": "a2", "label": "サービス品質向上と不正検知を実現", "category": "outcome"}
+        ],
+        "edges": []
+      },
+      "note": ""
+    }
+  ],
   "status": "seed",
   "created_at": "2026-03-07T00:00:00+09:00",
   "updated_at": "2026-03-07T00:00:00+09:00"

--- a/public/cases/anon-0014/case.json
+++ b/public/cases/anon-0014/case.json
@@ -29,7 +29,23 @@
       "url": "https://www.niigata-kouiki.jp/news/001306.html"
     }
   ],
-  "figures": [],
+  "figures": [
+    {
+      "type": "data_flow",
+      "title": "概要フロー",
+      "data": {
+        "nodes": [
+          {"id": "s1", "label": "レセプト・健診・介護データ", "category": "source"},
+          {"id": "s2", "label": "被保険者の個人情報保護が必要", "category": "constraint"},
+          {"id": "p1", "label": "匿名加工情報として第三者提供", "category": "process"},
+          {"id": "a1", "label": "データヘルス計画の費用対効果分析", "category": "application"},
+          {"id": "a2", "label": "保健事業の企画・評価を高度化", "category": "outcome"}
+        ],
+        "edges": []
+      },
+      "note": ""
+    }
+  ],
   "status": "seed",
   "created_at": "2026-03-08T00:00:00+09:00",
   "updated_at": "2026-03-08T00:00:00+09:00"

--- a/public/cases/anon-0015/case.json
+++ b/public/cases/anon-0015/case.json
@@ -29,7 +29,23 @@
       "url": "https://www.kyoukaikenpo.or.jp/shibu/miyagi/cat140/2023041102/"
     }
   ],
-  "figures": [],
+  "figures": [
+    {
+      "type": "data_flow",
+      "title": "概要フロー",
+      "data": {
+        "nodes": [
+          {"id": "s1", "label": "健診・睡眠・職域アンケートデータ", "category": "source"},
+          {"id": "s2", "label": "加入者の個人情報保護が必要", "category": "constraint"},
+          {"id": "p1", "label": "匿名加工情報として大学へ提供", "category": "process"},
+          {"id": "a1", "label": "睡眠・職域特性を踏まえた分析", "category": "application"},
+          {"id": "a2", "label": "多角的分析で保健事業を高度化", "category": "outcome"}
+        ],
+        "edges": []
+      },
+      "note": ""
+    }
+  ],
   "status": "seed",
   "created_at": "2026-03-08T00:00:00+09:00",
   "updated_at": "2026-03-08T00:00:00+09:00"

--- a/public/cases/anon-0016/case.json
+++ b/public/cases/anon-0016/case.json
@@ -40,7 +40,23 @@
       "url": "https://www.kyoukaikenpo.or.jp/shibu/ehime/cat080/20190228_01/20190226001/"
     }
   ],
-  "figures": [],
+  "figures": [
+    {
+      "type": "data_flow",
+      "title": "概要フロー",
+      "data": {
+        "nodes": [
+          {"id": "s1", "label": "健診・レセプトデータ（複数保険者）", "category": "source"},
+          {"id": "s2", "label": "保険者間のデータ共有に制約", "category": "constraint"},
+          {"id": "p1", "label": "匿名加工情報として県へ継続提供", "category": "process"},
+          {"id": "a1", "label": "ビッグデータ一元分析で課題特定", "category": "application"},
+          {"id": "a2", "label": "高血圧対策・減塩施策へ展開", "category": "outcome"}
+        ],
+        "edges": []
+      },
+      "note": ""
+    }
+  ],
   "status": "seed",
   "created_at": "2026-03-08T00:00:00+09:00",
   "updated_at": "2026-03-08T00:00:00+09:00"

--- a/public/cases/anon-0017/case.json
+++ b/public/cases/anon-0017/case.json
@@ -29,7 +29,23 @@
       "url": "https://www.ncrkenpo.or.jp/member/info/policy.html"
     }
   ],
-  "figures": [],
+  "figures": [
+    {
+      "type": "data_flow",
+      "title": "概要フロー",
+      "data": {
+        "nodes": [
+          {"id": "s1", "label": "レセプト・健診情報", "category": "source"},
+          {"id": "s2", "label": "他組合とのデータ比較に制約", "category": "constraint"},
+          {"id": "p1", "label": "匿名加工情報として第三者提供", "category": "process"},
+          {"id": "a1", "label": "他健保とのベンチマーク分析", "category": "application"},
+          {"id": "a2", "label": "保健指導・受診勧奨を改善", "category": "outcome"}
+        ],
+        "edges": []
+      },
+      "note": ""
+    }
+  ],
   "status": "seed",
   "created_at": "2026-03-08T00:00:00+09:00",
   "updated_at": "2026-03-08T00:00:00+09:00"

--- a/public/cases/anon-0018/case.json
+++ b/public/cases/anon-0018/case.json
@@ -30,7 +30,23 @@
       "url": "https://prtimes.jp/main/html/rd/p/000000490.000024308.html"
     }
   ],
-  "figures": [],
+  "figures": [
+    {
+      "type": "data_flow",
+      "title": "概要フロー",
+      "data": {
+        "nodes": [
+          {"id": "s1", "label": "患者の詳細な医療データ", "category": "source"},
+          {"id": "s2", "label": "匿名加工では検査値等が欠落", "category": "constraint"},
+          {"id": "p1", "label": "仮名加工医療情報として詳細保持", "category": "process"},
+          {"id": "a1", "label": "リアルワールドデータ構築・薬事承認", "category": "application"},
+          {"id": "a2", "label": "医薬品開発・個別化医療を加速", "category": "outcome"}
+        ],
+        "edges": []
+      },
+      "note": ""
+    }
+  ],
   "status": "seed",
   "created_at": "2026-03-08T00:00:00+09:00",
   "updated_at": "2026-03-08T00:00:00+09:00"

--- a/public/cases/anon-0019/case.json
+++ b/public/cases/anon-0019/case.json
@@ -29,7 +29,23 @@
       "url": "https://www.riken.jp/pr/news/2025/20250228_1/index.html"
     }
   ],
-  "figures": [],
+  "figures": [
+    {
+      "type": "data_flow",
+      "title": "概要フロー",
+      "data": {
+        "nodes": [
+          {"id": "s1", "label": "健康・医療データ（認定作成事業者）", "category": "source"},
+          {"id": "s2", "label": "詳細な医療データの研究利用に制約", "category": "constraint"},
+          {"id": "p1", "label": "仮名加工医療情報として安全に提供", "category": "process"},
+          {"id": "a1", "label": "AI予測医学・データ駆動型研究", "category": "application"},
+          {"id": "a2", "label": "先端研究の加速と医療の高度化", "category": "outcome"}
+        ],
+        "edges": []
+      },
+      "note": ""
+    }
+  ],
   "status": "seed",
   "created_at": "2026-03-08T00:00:00+09:00",
   "updated_at": "2026-03-08T00:00:00+09:00"

--- a/public/cases/fl-0001/case.json
+++ b/public/cases/fl-0001/case.json
@@ -31,7 +31,23 @@
       "url": "https://www.kobe-u.ac.jp/ja/news/article/2022_03_10_01/"
     }
   ],
-  "figures": [],
+  "figures": [
+    {
+      "type": "data_flow",
+      "title": "概要フロー",
+      "data": {
+        "nodes": [
+          {"id": "s1", "label": "複数銀行の取引データ", "category": "source"},
+          {"id": "s2", "label": "銀行間でデータ共有が困難", "category": "constraint"},
+          {"id": "p1", "label": "DeepProtectで連合学習", "category": "process"},
+          {"id": "a1", "label": "不正送金パターンの検知", "category": "application"},
+          {"id": "a2", "label": "検知精度80%以上を達成", "category": "outcome"}
+        ],
+        "edges": []
+      },
+      "note": ""
+    }
+  ],
   "status": "seed",
   "created_at": "2022-03-10T00:00:00+09:00",
   "updated_at": "2026-03-07T00:00:00+09:00"

--- a/public/cases/fl-0002/case.json
+++ b/public/cases/fl-0002/case.json
@@ -31,7 +31,23 @@
       "url": "https://www.nict.go.jp/press/2025/06/10-1.html"
     }
   ],
-  "figures": [],
+  "figures": [
+    {
+      "type": "data_flow",
+      "title": "概要フロー",
+      "data": {
+        "nodes": [
+          {"id": "s1", "label": "4銀行の口座データ", "category": "source"},
+          {"id": "s2", "label": "元データを銀行間で共有不可", "category": "constraint"},
+          {"id": "p1", "label": "連合学習＋アンサンブル学習", "category": "process"},
+          {"id": "a1", "label": "不正口座の検知", "category": "application"},
+          {"id": "a2", "label": "適合率10pt向上・再現率95%超", "category": "outcome"}
+        ],
+        "edges": []
+      },
+      "note": ""
+    }
+  ],
   "status": "seed",
   "created_at": "2025-06-10T00:00:00+09:00",
   "updated_at": "2026-03-07T00:00:00+09:00"

--- a/public/cases/fl-0003/case.json
+++ b/public/cases/fl-0003/case.json
@@ -31,7 +31,23 @@
       "url": "https://www.nict.go.jp/press/2025/07/22-1.html"
     }
   ],
-  "figures": [],
+  "figures": [
+    {
+      "type": "data_flow",
+      "title": "概要フロー",
+      "data": {
+        "nodes": [
+          {"id": "s1", "label": "3銀行の送金データ", "category": "source"},
+          {"id": "s2", "label": "犯罪手口が日々変化", "category": "constraint"},
+          {"id": "p1", "label": "DeepProtect+eFL-Boostで継続学習", "category": "process"},
+          {"id": "a1", "label": "変化する不正送金の検知", "category": "application"},
+          {"id": "a2", "label": "再現率が平均18pt改善", "category": "outcome"}
+        ],
+        "edges": []
+      },
+      "note": ""
+    }
+  ],
   "status": "seed",
   "created_at": "2025-07-22T00:00:00+09:00",
   "updated_at": "2026-03-07T00:00:00+09:00"

--- a/public/cases/psd-0001/case.json
+++ b/public/cases/psd-0001/case.json
@@ -25,7 +25,23 @@
       "url": "https://www.census.gov/content/dam/Census/programs-surveys/sipp/methodology/SSBdescribe_nontechnical.pdf"
     }
   ],
-  "figures": [],
+  "figures": [
+    {
+      "type": "data_flow",
+      "title": "概要フロー",
+      "data": {
+        "nodes": [
+          {"id": "s1", "label": "SIPP調査＋税・給付行政データ", "category": "source"},
+          {"id": "s2", "label": "機微な所得情報で公開困難", "category": "constraint"},
+          {"id": "p1", "label": "機微変数を合成値で部分置換", "category": "process"},
+          {"id": "a1", "label": "研究者向けに公開データ提供", "category": "application"},
+          {"id": "a2", "label": "プライバシー保護と研究利用を両立", "category": "outcome"}
+        ],
+        "edges": []
+      },
+      "note": ""
+    }
+  ],
   "status": "seed",
   "created_at": "2026-03-07T00:00:00+09:00",
   "updated_at": "2026-03-07T00:00:00+09:00"

--- a/public/cases/psd-0002/case.json
+++ b/public/cases/psd-0002/case.json
@@ -25,7 +25,23 @@
       "url": "https://lehd.ces.census.gov/doc/help/OTMSyntheticData%2005262009-jma.pdf"
     }
   ],
-  "figures": [],
+  "figures": [
+    {
+      "type": "data_flow",
+      "title": "概要フロー",
+      "data": {
+        "nodes": [
+          {"id": "s1", "label": "就業地・居住地の地理データ", "category": "source"},
+          {"id": "s2", "label": "居住地情報の秘匿保護が必要", "category": "constraint"},
+          {"id": "p1", "label": "居住地側のみ部分合成データ化", "category": "process"},
+          {"id": "a1", "label": "地理的分布の分析に活用", "category": "application"},
+          {"id": "a2", "label": "秘匿保護しつつ地理分析を実現", "category": "outcome"}
+        ],
+        "edges": []
+      },
+      "note": ""
+    }
+  ],
   "status": "seed",
   "created_at": "2026-03-07T00:00:00+09:00",
   "updated_at": "2026-03-07T00:00:00+09:00"

--- a/public/cases/psd-0003/case.json
+++ b/public/cases/psd-0003/case.json
@@ -20,7 +20,23 @@
       "url": "https://nces.ed.gov/FCSM/pdf/2007FCSM_Hawala-IX-B.pdf"
     }
   ],
-  "figures": [],
+  "figures": [
+    {
+      "type": "data_flow",
+      "title": "概要フロー",
+      "data": {
+        "nodes": [
+          {"id": "s1", "label": "退役軍人の統計データ", "category": "source"},
+          {"id": "s2", "label": "稀少レコードで個人識別リスク", "category": "constraint"},
+          {"id": "p1", "label": "高リスク変数のみ選択的に合成", "category": "process"},
+          {"id": "a1", "label": "統計分析・政策立案に活用", "category": "application"},
+          {"id": "a2", "label": "全件合成より精度を維持し秘匿化", "category": "outcome"}
+        ],
+        "edges": []
+      },
+      "note": ""
+    }
+  ],
   "status": "seed",
   "created_at": "2026-03-07T00:00:00+09:00",
   "updated_at": "2026-03-07T00:00:00+09:00"

--- a/public/cases/psd-0004/case.json
+++ b/public/cases/psd-0004/case.json
@@ -20,7 +20,23 @@
       "url": "https://datasciencecampus.ons.gov.uk/synthesising-the-linked-2011-census-and-deaths-dataset-while-preserving-its-confidentiality/"
     }
   ],
-  "figures": [],
+  "figures": [
+    {
+      "type": "data_flow",
+      "title": "概要フロー",
+      "data": {
+        "nodes": [
+          {"id": "s1", "label": "国勢調査＋死亡登録の連結データ", "category": "source"},
+          {"id": "s2", "label": "高機微な連結データで公開不可", "category": "constraint"},
+          {"id": "p1", "label": "連結データを合成データ化", "category": "process"},
+          {"id": "a1", "label": "研究者向け分析用データ公開", "category": "application"},
+          {"id": "a2", "label": "機密データの安全な公開を実現", "category": "outcome"}
+        ],
+        "edges": []
+      },
+      "note": ""
+    }
+  ],
   "status": "seed",
   "created_at": "2026-03-07T00:00:00+09:00",
   "updated_at": "2026-03-07T00:00:00+09:00"

--- a/public/cases/psd-0005/case.json
+++ b/public/cases/psd-0005/case.json
@@ -20,7 +20,23 @@
       "url": "https://www.gov.uk/guidance/repository-of-privacy-enhancing-technologies-pets-use-cases/national-statistics-education-and-transport"
     }
   ],
-  "figures": [],
+  "figures": [
+    {
+      "type": "data_flow",
+      "title": "概要フロー",
+      "data": {
+        "nodes": [
+          {"id": "s1", "label": "国勢調査・死亡レジストリ等", "category": "source"},
+          {"id": "s2", "label": "高リスクデータで外部提供不可", "category": "constraint"},
+          {"id": "p1", "label": "分析価値を保ち合成データ化", "category": "process"},
+          {"id": "a1", "label": "ハッカソン・教育用途に提供", "category": "application"},
+          {"id": "a2", "label": "安全に教育・研究利用を促進", "category": "outcome"}
+        ],
+        "edges": []
+      },
+      "note": ""
+    }
+  ],
   "status": "seed",
   "created_at": "2026-03-07T00:00:00+09:00",
   "updated_at": "2026-03-07T00:00:00+09:00"

--- a/public/cases/psd-0006/case.json
+++ b/public/cases/psd-0006/case.json
@@ -20,7 +20,23 @@
       "url": "https://www.jmra-net.or.jp/Portals/0/committee/statistics/nenji2024_material_2.pdf"
     }
   ],
-  "figures": [],
+  "figures": [
+    {
+      "type": "data_flow",
+      "title": "概要フロー",
+      "data": {
+        "nodes": [
+          {"id": "s1", "label": "複数の公的統計データソース", "category": "source"},
+          {"id": "s2", "label": "異なるデータの直接結合が困難", "category": "constraint"},
+          {"id": "p1", "label": "共通変数で統計的マッチング", "category": "process"},
+          {"id": "a1", "label": "疑似結合パネルデータの作成", "category": "application"},
+          {"id": "a2", "label": "情報量を増加し分析精度向上", "category": "outcome"}
+        ],
+        "edges": []
+      },
+      "note": ""
+    }
+  ],
   "status": "seed",
   "created_at": "2026-03-07T00:00:00+09:00",
   "updated_at": "2026-03-07T00:00:00+09:00"

--- a/public/cases/sc-0001/case.json
+++ b/public/cases/sc-0001/case.json
@@ -20,7 +20,23 @@
       "url": "https://group.ntt/jp/newsrelease/pdf/news2012/1202/120214a.pdf"
     }
   ],
-  "figures": [],
+  "figures": [
+    {
+      "type": "data_flow",
+      "title": "概要フロー",
+      "data": {
+        "nodes": [
+          {"id": "s1", "label": "約1,000症例×800項目の臨床データ", "category": "source"},
+          {"id": "s2", "label": "生データを研究者に開示できない", "category": "constraint"},
+          {"id": "p1", "label": "秘密計算で暗号化したまま統計処理", "category": "process"},
+          {"id": "a1", "label": "平均・分散・t検定等の医療統計", "category": "application"},
+          {"id": "a2", "label": "生データ非開示で多施設研究を実現", "category": "outcome"}
+        ],
+        "edges": []
+      },
+      "note": ""
+    }
+  ],
   "status": "seed",
   "created_at": "2026-03-08T00:00:00+09:00",
   "updated_at": "2026-03-08T00:00:00+09:00"

--- a/public/cases/sc-0002/case.json
+++ b/public/cases/sc-0002/case.json
@@ -20,7 +20,23 @@
       "url": "https://group.ntt/jp/newsrelease/2016/07/12/160712a.html"
     }
   ],
-  "figures": [],
+  "figures": [
+    {
+      "type": "data_flow",
+      "title": "概要フロー",
+      "data": {
+        "nodes": [
+          {"id": "s1", "label": "複数機関のゲノムデータ", "category": "source"},
+          {"id": "s2", "label": "機微データを持ち寄れずサンプル不足", "category": "constraint"},
+          {"id": "p1", "label": "秘密計算でフィッシャー検定を実行", "category": "process"},
+          {"id": "a1", "label": "ゲノムワイド関連解析", "category": "application"},
+          {"id": "a2", "label": "データ非開示で大規模ゲノム研究", "category": "outcome"}
+        ],
+        "edges": []
+      },
+      "note": ""
+    }
+  ],
   "status": "seed",
   "created_at": "2026-03-08T00:00:00+09:00",
   "updated_at": "2026-03-08T00:00:00+09:00"

--- a/public/cases/sc-0003/case.json
+++ b/public/cases/sc-0003/case.json
@@ -20,7 +20,23 @@
       "url": "https://jpn.nec.com/press/201907/20190723_03.html"
     }
   ],
-  "figures": [],
+  "figures": [
+    {
+      "type": "data_flow",
+      "title": "概要フロー",
+      "data": {
+        "nodes": [
+          {"id": "s1", "label": "複数機関のゲノム・疾病情報", "category": "source"},
+          {"id": "s2", "label": "機関間でデータを直接共有できない", "category": "constraint"},
+          {"id": "p1", "label": "秘密計算で秘匿結合・集計分析", "category": "process"},
+          {"id": "a1", "label": "年代別ゲノム変異頻度の解析", "category": "application"},
+          {"id": "a2", "label": "多機関データで個別化医療を推進", "category": "outcome"}
+        ],
+        "edges": []
+      },
+      "note": ""
+    }
+  ],
   "status": "seed",
   "created_at": "2026-03-08T00:00:00+09:00",
   "updated_at": "2026-03-08T00:00:00+09:00"

--- a/public/cases/sc-0004/case.json
+++ b/public/cases/sc-0004/case.json
@@ -20,7 +20,23 @@
       "url": "https://www.ntt.com/about-us/press-releases/news/article/2021/0208.html"
     }
   ],
-  "figures": [],
+  "figures": [
+    {
+      "type": "data_flow",
+      "title": "概要フロー",
+      "data": {
+        "nodes": [
+          {"id": "s1", "label": "複数施設の希少疾患臨床データ", "category": "source"},
+          {"id": "s2", "label": "単施設では症例数が不足", "category": "constraint"},
+          {"id": "p1", "label": "秘密計算DLで秘匿のままAI学習", "category": "process"},
+          {"id": "a1", "label": "診断支援・薬剤選定AIの構築", "category": "application"},
+          {"id": "a2", "label": "データ非開示で多施設共同研究", "category": "outcome"}
+        ],
+        "edges": []
+      },
+      "note": ""
+    }
+  ],
   "status": "seed",
   "created_at": "2026-03-08T00:00:00+09:00",
   "updated_at": "2026-03-08T00:00:00+09:00"

--- a/public/cases/sc-0005/case.json
+++ b/public/cases/sc-0005/case.json
@@ -20,7 +20,23 @@
       "url": "https://www.ntt.com/about-us/press-releases/news/article/2022/1129.html"
     }
   ],
-  "figures": [],
+  "figures": [
+    {
+      "type": "data_flow",
+      "title": "概要フロー",
+      "data": {
+        "nodes": [
+          {"id": "s1", "label": "患者のePRO入力データ", "category": "source"},
+          {"id": "s2", "label": "私生活情報を医師に直接見せられない", "category": "constraint"},
+          {"id": "p1", "label": "秘密計算でePROを秘匿分析", "category": "process"},
+          {"id": "a1", "label": "IBDの新知見獲得・治療改善", "category": "application"},
+          {"id": "a2", "label": "患者が安心して情報提供でき研究促進", "category": "outcome"}
+        ],
+        "edges": []
+      },
+      "note": ""
+    }
+  ],
   "status": "seed",
   "created_at": "2026-03-08T00:00:00+09:00",
   "updated_at": "2026-03-08T00:00:00+09:00"

--- a/public/cases/sc-0006/case.json
+++ b/public/cases/sc-0006/case.json
@@ -20,7 +20,23 @@
       "url": "https://prtimes.jp/main/html/rd/p/000000014.000046917.html"
     }
   ],
-  "figures": [],
+  "figures": [
+    {
+      "type": "data_flow",
+      "title": "概要フロー",
+      "data": {
+        "nodes": [
+          {"id": "s1", "label": "顧客アンケート＋DMP属性データ", "category": "source"},
+          {"id": "s2", "label": "企業間でプライバシーデータ共有不可", "category": "constraint"},
+          {"id": "p1", "label": "秘密計算(MPC)で暗号化突合・分析", "category": "process"},
+          {"id": "a1", "label": "マーケティング相関分析", "category": "application"},
+          {"id": "a2", "label": "高精度かつプライバシー保護の分析", "category": "outcome"}
+        ],
+        "edges": []
+      },
+      "note": ""
+    }
+  ],
   "status": "seed",
   "created_at": "2026-03-08T00:00:00+09:00",
   "updated_at": "2026-03-08T00:00:00+09:00"

--- a/public/cases/sc-0007/case.json
+++ b/public/cases/sc-0007/case.json
@@ -20,7 +20,23 @@
       "url": "https://prtimes.jp/main/html/rd/p/000000013.000046917.html"
     }
   ],
-  "figures": [],
+  "figures": [
+    {
+      "type": "data_flow",
+      "title": "概要フロー",
+      "data": {
+        "nodes": [
+          {"id": "s1", "label": "複数病院の約6万人分医療行為データ", "category": "source"},
+          {"id": "s2", "label": "病院間で患者データを共有できない", "category": "constraint"},
+          {"id": "p1", "label": "秘密計算(QuickMPC)で秘匿統合分析", "category": "process"},
+          {"id": "a1", "label": "医療サービス格差の分析", "category": "application"},
+          {"id": "a2", "label": "生データ同等精度で格差を可視化", "category": "outcome"}
+        ],
+        "edges": []
+      },
+      "note": ""
+    }
+  ],
   "status": "seed",
   "created_at": "2026-03-08T00:00:00+09:00",
   "updated_at": "2026-03-08T00:00:00+09:00"

--- a/public/cases/sc-0008/case.json
+++ b/public/cases/sc-0008/case.json
@@ -20,7 +20,23 @@
       "url": "https://prtimes.jp/main/html/rd/p/000000042.000046917.html"
     }
   ],
-  "figures": [],
+  "figures": [
+    {
+      "type": "data_flow",
+      "title": "概要フロー",
+      "data": {
+        "nodes": [
+          {"id": "s1", "label": "複数病院のDPCデータ", "category": "source"},
+          {"id": "s2", "label": "病院間で経営データの開示が困難", "category": "constraint"},
+          {"id": "p1", "label": "SMPCで秘匿したまま統計値を算出", "category": "process"},
+          {"id": "a1", "label": "診療科別の経営指標を比較分析", "category": "application"},
+          {"id": "a2", "label": "機密性を保ちつつベンチマーク分析を実現", "category": "outcome"}
+        ],
+        "edges": []
+      },
+      "note": ""
+    }
+  ],
   "status": "seed",
   "created_at": "2026-03-08T00:00:00+09:00",
   "updated_at": "2026-03-08T00:00:00+09:00"

--- a/public/cases/sc-0009/case.json
+++ b/public/cases/sc-0009/case.json
@@ -20,7 +20,23 @@
       "url": "https://eaglys.co.jp/resource/news/press-release/20221110"
     }
   ],
-  "figures": [],
+  "figures": [
+    {
+      "type": "data_flow",
+      "title": "概要フロー",
+      "data": {
+        "nodes": [
+          {"id": "s1", "label": "創薬・素材の研究データとAIモデル", "category": "source"},
+          {"id": "s2", "label": "データもモデルも企業秘密で共有困難", "category": "constraint"},
+          {"id": "p1", "label": "秘密計算で特徴量抽出〜推論を処理", "category": "process"},
+          {"id": "a1", "label": "秘匿したままAIモデルを共有・活用", "category": "application"},
+          {"id": "a2", "label": "平文比2〜4倍の現実的な処理時間を実証", "category": "outcome"}
+        ],
+        "edges": []
+      },
+      "note": ""
+    }
+  ],
   "status": "seed",
   "created_at": "2026-03-08T00:00:00+09:00",
   "updated_at": "2026-03-08T00:00:00+09:00"

--- a/public/cases/sc-0010/case.json
+++ b/public/cases/sc-0010/case.json
@@ -20,7 +20,23 @@
       "url": "https://www.mcgc.com/news_release/pdf/02395/02654.pdf"
     }
   ],
-  "figures": [],
+  "figures": [
+    {
+      "type": "data_flow",
+      "title": "概要フロー",
+      "data": {
+        "nodes": [
+          {"id": "s1", "label": "サプライチェーン各社の材料データ", "category": "source"},
+          {"id": "s2", "label": "機密データのため直接開示が不可", "category": "constraint"},
+          {"id": "p1", "label": "ALCHEMISTAで秘密計算MI分析", "category": "process"},
+          {"id": "a1", "label": "企業間データ連携で新規材料を開発", "category": "application"},
+          {"id": "a2", "label": "開発期間を2〜3年から1年未満に短縮", "category": "outcome"}
+        ],
+        "edges": []
+      },
+      "note": ""
+    }
+  ],
   "status": "seed",
   "created_at": "2026-03-08T00:00:00+09:00",
   "updated_at": "2026-03-08T00:00:00+09:00"

--- a/public/cases/sc-0011/case.json
+++ b/public/cases/sc-0011/case.json
@@ -20,7 +20,23 @@
       "url": "https://www.nict.go.jp/press/2022/03/10-1.html"
     }
   ],
-  "figures": [],
+  "figures": [
+    {
+      "type": "data_flow",
+      "title": "概要フロー",
+      "data": {
+        "nodes": [
+          {"id": "s1", "label": "銀行5行の取引データ", "category": "source"},
+          {"id": "s2", "label": "競争関係で取引データの相互開示不可", "category": "constraint"},
+          {"id": "p1", "label": "DeepProtectで連合学習モデルを構築", "category": "process"},
+          {"id": "a1", "label": "銀行横断の不正送金検知に適用", "category": "application"},
+          {"id": "a2", "label": "検知精度80%以上を達成し共同防御実現", "category": "outcome"}
+        ],
+        "edges": []
+      },
+      "note": ""
+    }
+  ],
   "status": "seed",
   "created_at": "2026-03-08T00:00:00+09:00",
   "updated_at": "2026-03-08T00:00:00+09:00"

--- a/public/cases/sc-0012/case.json
+++ b/public/cases/sc-0012/case.json
@@ -20,7 +20,23 @@
       "url": "https://www.nict.go.jp/press/2025/06/10-1.html"
     }
   ],
-  "figures": [],
+  "figures": [
+    {
+      "type": "data_flow",
+      "title": "概要フロー",
+      "data": {
+        "nodes": [
+          {"id": "s1", "label": "銀行4行の口座・取引データ", "category": "source"},
+          {"id": "s2", "label": "銀行間でデータ開示ができない制約", "category": "constraint"},
+          {"id": "p1", "label": "DeepProtectで連合＋個別のアンサンブル学習", "category": "process"},
+          {"id": "a1", "label": "不正口座検知の精度向上に活用", "category": "application"},
+          {"id": "a2", "label": "AMLシステムとの並行運用を検討可能に", "category": "outcome"}
+        ],
+        "edges": []
+      },
+      "note": ""
+    }
+  ],
   "status": "seed",
   "created_at": "2026-03-08T00:00:00+09:00",
   "updated_at": "2026-03-08T00:00:00+09:00"

--- a/public/cases/sc-0013/case.json
+++ b/public/cases/sc-0013/case.json
@@ -20,7 +20,23 @@
       "url": "https://jpn.nec.com/press/202209/20220928_03.html"
     }
   ],
-  "figures": [],
+  "figures": [
+    {
+      "type": "data_flow",
+      "title": "概要フロー",
+      "data": {
+        "nodes": [
+          {"id": "s1", "label": "プラント装置のログデータ", "category": "source"},
+          {"id": "s2", "label": "営業機密性が高く外部分析が困難", "category": "constraint"},
+          {"id": "p1", "label": "MPC方式で3サーバに秘密分散し分析", "category": "process"},
+          {"id": "a1", "label": "暗号化したまま異常検知ルールと突合", "category": "application"},
+          {"id": "a2", "label": "機密ログの安全なクラウド分析を実現", "category": "outcome"}
+        ],
+        "edges": []
+      },
+      "note": ""
+    }
+  ],
   "status": "seed",
   "created_at": "2026-03-08T00:00:00+09:00",
   "updated_at": "2026-03-08T00:00:00+09:00"

--- a/public/cases/seed-0011/case.json
+++ b/public/cases/seed-0011/case.json
@@ -35,7 +35,23 @@
     }
   ],
   "id": "seed-0011",
-  "figures": [],
+  "figures": [
+    {
+      "type": "data_flow",
+      "title": "概要フロー",
+      "data": {
+        "nodes": [
+          {"id": "s1", "label": "COVID-19の診療データ", "category": "source"},
+          {"id": "s2", "label": "患者プライバシーで外部共有が困難", "category": "constraint"},
+          {"id": "p1", "label": "合成データを生成し外部配布用に変換", "category": "process"},
+          {"id": "a1", "label": "入院リスク予測や流行曲線予測に活用", "category": "application"},
+          {"id": "a2", "label": "実データとほぼ同等の分析結果を確認", "category": "outcome"}
+        ],
+        "edges": []
+      },
+      "note": ""
+    }
+  ],
   "status": "seed",
   "created_at": "2026-02-26T00:00:00+09:00",
   "updated_at": "2026-03-04T00:49:07.565Z"


### PR DESCRIPTION
## Summary

- 概要図（data_flow）が未設定だった全41事例にフロー図を追加
- 各事例のsummary・value_propositionに基づき、3列レイアウト（データ収集→処理・生成→データ活用）で作成
- 各図は source / constraint / process / application / outcome の5ノード構成

### 対象事例

| カテゴリ | 件数 | ID |
|---------|------|----|
| 匿名加工・仮名加工 | 17件 | anon-0001〜anon-0019 |
| 連合学習 | 3件 | fl-0001〜fl-0003 |
| 部分合成データ | 6件 | psd-0001〜psd-0006 |
| 秘密計算 | 13件 | sc-0001〜sc-0013 |
| その他 | 1件 | seed-0011 |

## Test plan

- [x] 全41件のJSON バリデーション通過
- [x] `npx vitest run` — 175テスト全パス
- [ ] ブラウザ確認: 各事例の詳細ページに概要フロー図が表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)