### PR TITLE
fix: 配列フィールドの集計方法を改善し延べ件数の注釈を追加 (closes #42)

### DIFF
--- a/src/components/case-list/SummaryPanel.tsx
+++ b/src/components/case-list/SummaryPanel.tsx
@@ -167,7 +167,8 @@ export default function SummaryPanel({ filteredCases, totalCases, filters, onTog
         </div>
 
         <div className="bg-white rounded-lg shadow px-4 py-3">
-          <h3 className="text-sm font-semibold text-gray-700 mb-2">ユースケース分類別</h3>
+          <h3 className="text-sm font-semibold text-gray-700 mb-1">ユースケース分類別</h3>
+          <p className="text-[11px] text-gray-400 mb-2">※ 複数分類にまたがる事例あり</p>
           <StackedBar
             items={categoryItems}
             colorMap={CATEGORY_COLORS}

--- a/src/lib/summary.ts
+++ b/src/lib/summary.ts
@@ -17,12 +17,14 @@ export interface CaseSummary {
   byReviewStatus: CountItem[]
 }
 
-/** Count cases grouped by a specific field */
+/** Count cases grouped by a specific field.
+ *  For array fields (usecase_category, technology_category), percentage is
+ *  based on the sum of all assignments so that stacked bars add up to 100%.
+ */
 export function countByField(
   cases: Case[],
   field: 'region' | 'domain' | 'usecase_category' | 'technology_category' | 'review_status',
 ): CountItem[] {
-  const total = cases.length
   const counts = new Map<string, number>()
 
   for (const c of cases) {
@@ -36,11 +38,15 @@ export function countByField(
     }
   }
 
+  // For array fields, use sum of counts so stacked bar totals 100%
+  const sumCounts = Array.from(counts.values()).reduce((a, b) => a + b, 0)
+  const denominator = sumCounts > 0 ? sumCounts : 1
+
   return Array.from(counts.entries())
     .map(([label, count]) => ({
       label,
       count,
-      percentage: total === 0 ? 0 : Math.round((count / total) * 1000) / 10,
+      percentage: Math.round((count / denominator) * 1000) / 10,
     }))
     .sort((a, b) => b.count - a.count)
 }

--- a/src/pages/StatsPage.tsx
+++ b/src/pages/StatsPage.tsx
@@ -9,10 +9,11 @@ interface BarItem {
   color: string
 }
 
-function HorizontalBarChart({ title, items, maxCount }: { title: string; items: BarItem[]; maxCount: number }) {
+function HorizontalBarChart({ title, items, maxCount, note }: { title: string; items: BarItem[]; maxCount: number; note?: string }) {
   return (
     <div className="bg-white rounded-lg shadow px-5 py-4">
-      <h3 className="text-sm font-semibold text-gray-700 mb-3">{title}</h3>
+      <h3 className="text-sm font-semibold text-gray-700 mb-1">{title}</h3>
+      {note && <p className="text-[11px] text-gray-400 mb-2">{note}</p>}
       <div className="space-y-2">
         {items.map((item) => (
           <div key={item.label} className="flex items-center gap-3">
@@ -312,10 +313,10 @@ export default function StatsPage() {
 
       {/* Charts grid */}
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
-        <HorizontalBarChart title="技術カテゴリ別" items={stats.techItems} maxCount={maxTech} />
+        <HorizontalBarChart title="技術カテゴリ別" items={stats.techItems} maxCount={maxTech} note="※ 複数技術を併用する事例があるため、合計は総事例数を超えます" />
         <HorizontalBarChart title="分野別" items={stats.domainItems} maxCount={maxDomain} />
         <HorizontalBarChart title="地域別" items={stats.regionItems} maxCount={maxRegion} />
-        <HorizontalBarChart title="ユースケース分類別" items={stats.usecaseItems} maxCount={maxUsecase} />
+        <HorizontalBarChart title="ユースケース分類別" items={stats.usecaseItems} maxCount={maxUsecase} note="※ 複数分類にまたがる事例があるため、合計は総事例数を超えます" />
         <HorizontalBarChart title="レビュー状態別" items={stats.reviewItems} maxCount={maxReview} />
       </div>
     </div>


### PR DESCRIPTION
## Summary

- **summary.ts**: `countByField` の percentage 計算を修正。配列フィールド（technology_category, usecase_category）では割り当て総数を分母に使用し、StackedBar が 100% を超えないよう修正
- **StatsPage**: 技術カテゴリ別・ユースケース分類別のバーチャートに「複数技術/分類にまたがる事例があるため、合計は総事例数を超えます」の注釈を追加
- **SummaryPanel**: ユースケース分類に「複数分類にまたがる事例あり」の注釈を追加

Closes #42

## Test plan

- [x] `npx vitest run` — 175テスト全パス
- [ ] ブラウザ確認: 統計ページで技術カテゴリ・ユースケース分類の注釈が表示されること
- [ ] ブラウザ確認: 一覧ページのStackedBarが100%を超えないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)