### PR TITLE
fix: da-事例11件のfigures構造を修正

### DIFF
--- a/public/cases/da-0001/case.json
+++ b/public/cases/da-0001/case.json
@@ -35,19 +35,57 @@
       "type": "data_flow",
       "title": "DARWIN EUのデータフロー",
       "note": "",
-      "nodes": [
-        { "id": "s1", "label": "欧州各国の医療データベース（OMOP CDM）", "category": "source" },
-        { "id": "s2", "label": "患者データ移動の規制制約", "category": "constraint" },
-        { "id": "p1", "label": "解析コードを各施設に分散実行", "category": "process" },
-        { "id": "a1", "label": "集約結果によるRWE生成", "category": "application" },
-        { "id": "a2", "label": "医薬品規制判断の迅速化", "category": "outcome" }
-      ],
-      "edges": [
-        { "from": "s1", "to": "p1", "label": "標準化データ" },
-        { "from": "s2", "to": "p1", "label": "データ移動なし" },
-        { "from": "p1", "to": "a1", "label": "分散解析結果" },
-        { "from": "a1", "to": "a2", "label": "エビデンス提供" }
-      ]
+      "data": {
+        "nodes": [
+          {
+            "id": "s1",
+            "label": "欧州各国の医療データベース（OMOP CDM）",
+            "category": "source"
+          },
+          {
+            "id": "s2",
+            "label": "患者データ移動の規制制約",
+            "category": "constraint"
+          },
+          {
+            "id": "p1",
+            "label": "解析コードを各施設に分散実行",
+            "category": "process"
+          },
+          {
+            "id": "a1",
+            "label": "集約結果によるRWE生成",
+            "category": "application"
+          },
+          {
+            "id": "a2",
+            "label": "医薬品規制判断の迅速化",
+            "category": "outcome"
+          }
+        ],
+        "edges": [
+          {
+            "from": "s1",
+            "to": "p1",
+            "label": "標準化データ"
+          },
+          {
+            "from": "s2",
+            "to": "p1",
+            "label": "データ移動なし"
+          },
+          {
+            "from": "p1",
+            "to": "a1",
+            "label": "分散解析結果"
+          },
+          {
+            "from": "a1",
+            "to": "a2",
+            "label": "エビデンス提供"
+          }
+        ]
+      }
     }
   ],
   "status": "seed",

--- a/public/cases/da-0002/case.json
+++ b/public/cases/da-0002/case.json
@@ -35,19 +35,57 @@
       "type": "data_flow",
       "title": "EHDENのデータフロー",
       "note": "",
-      "nodes": [
-        { "id": "s1", "label": "20カ国超の医療データベース", "category": "source" },
-        { "id": "s2", "label": "各国データ保護規制", "category": "constraint" },
-        { "id": "p1", "label": "OMOP CDMで標準化＋分散解析実行", "category": "process" },
-        { "id": "a1", "label": "薬剤安全性シグナルの検証", "category": "application" },
-        { "id": "a2", "label": "大規模な安全性エビデンス生成", "category": "outcome" }
-      ],
-      "edges": [
-        { "from": "s1", "to": "p1", "label": "各国データ" },
-        { "from": "s2", "to": "p1", "label": "データ移動制限" },
-        { "from": "p1", "to": "a1", "label": "分散解析結果" },
-        { "from": "a1", "to": "a2", "label": "シグナル検証" }
-      ]
+      "data": {
+        "nodes": [
+          {
+            "id": "s1",
+            "label": "20カ国超の医療データベース",
+            "category": "source"
+          },
+          {
+            "id": "s2",
+            "label": "各国データ保護規制",
+            "category": "constraint"
+          },
+          {
+            "id": "p1",
+            "label": "OMOP CDMで標準化＋分散解析実行",
+            "category": "process"
+          },
+          {
+            "id": "a1",
+            "label": "薬剤安全性シグナルの検証",
+            "category": "application"
+          },
+          {
+            "id": "a2",
+            "label": "大規模な安全性エビデンス生成",
+            "category": "outcome"
+          }
+        ],
+        "edges": [
+          {
+            "from": "s1",
+            "to": "p1",
+            "label": "各国データ"
+          },
+          {
+            "from": "s2",
+            "to": "p1",
+            "label": "データ移動制限"
+          },
+          {
+            "from": "p1",
+            "to": "a1",
+            "label": "分散解析結果"
+          },
+          {
+            "from": "a1",
+            "to": "a2",
+            "label": "シグナル検証"
+          }
+        ]
+      }
     }
   ],
   "status": "seed",

--- a/public/cases/da-0003/case.json
+++ b/public/cases/da-0003/case.json
@@ -35,19 +35,57 @@
       "type": "data_flow",
       "title": "EHDEN/OHDSI COVID-19分散解析のデータフロー",
       "note": "",
-      "nodes": [
-        { "id": "s1", "label": "OHDSIネットワークの13データベース", "category": "source" },
-        { "id": "s2", "label": "パンデミック下のデータ移動制約", "category": "constraint" },
-        { "id": "p1", "label": "標準化解析パッケージのローカル実行", "category": "process" },
-        { "id": "a1", "label": "AESI背景発生率の集約", "category": "application" },
-        { "id": "a2", "label": "国際的ベースラインデータの確立", "category": "outcome" }
-      ],
-      "edges": [
-        { "from": "s1", "to": "p1", "label": "OMOP CDMデータ" },
-        { "from": "s2", "to": "p1", "label": "データ移動なし" },
-        { "from": "p1", "to": "a1", "label": "分散解析結果" },
-        { "from": "a1", "to": "a2", "label": "背景発生率の統合" }
-      ]
+      "data": {
+        "nodes": [
+          {
+            "id": "s1",
+            "label": "OHDSIネットワークの13データベース",
+            "category": "source"
+          },
+          {
+            "id": "s2",
+            "label": "パンデミック下のデータ移動制約",
+            "category": "constraint"
+          },
+          {
+            "id": "p1",
+            "label": "標準化解析パッケージのローカル実行",
+            "category": "process"
+          },
+          {
+            "id": "a1",
+            "label": "AESI背景発生率の集約",
+            "category": "application"
+          },
+          {
+            "id": "a2",
+            "label": "国際的ベースラインデータの確立",
+            "category": "outcome"
+          }
+        ],
+        "edges": [
+          {
+            "from": "s1",
+            "to": "p1",
+            "label": "OMOP CDMデータ"
+          },
+          {
+            "from": "s2",
+            "to": "p1",
+            "label": "データ移動なし"
+          },
+          {
+            "from": "p1",
+            "to": "a1",
+            "label": "分散解析結果"
+          },
+          {
+            "from": "a1",
+            "to": "a2",
+            "label": "背景発生率の統合"
+          }
+        ]
+      }
     }
   ],
   "status": "seed",

--- a/public/cases/da-0004/case.json
+++ b/public/cases/da-0004/case.json
@@ -35,19 +35,57 @@
       "type": "data_flow",
       "title": "OHDSI小児治験フィージビリティのデータフロー",
       "note": "",
-      "nodes": [
-        { "id": "s1", "label": "OHDSI参加医療機関のデータベース", "category": "source" },
-        { "id": "s2", "label": "小児データの保護要件", "category": "constraint" },
-        { "id": "p1", "label": "OMOP CDM + 分散クエリ実行", "category": "process" },
-        { "id": "a1", "label": "患者数・適格基準の充足分析", "category": "application" },
-        { "id": "a2", "label": "治験フィージビリティ評価", "category": "outcome" }
-      ],
-      "edges": [
-        { "from": "s1", "to": "p1", "label": "標準化データ" },
-        { "from": "s2", "to": "p1", "label": "データ移動なし" },
-        { "from": "p1", "to": "a1", "label": "集計結果" },
-        { "from": "a1", "to": "a2", "label": "フィージビリティ判定" }
-      ]
+      "data": {
+        "nodes": [
+          {
+            "id": "s1",
+            "label": "OHDSI参加医療機関のデータベース",
+            "category": "source"
+          },
+          {
+            "id": "s2",
+            "label": "小児データの保護要件",
+            "category": "constraint"
+          },
+          {
+            "id": "p1",
+            "label": "OMOP CDM + 分散クエリ実行",
+            "category": "process"
+          },
+          {
+            "id": "a1",
+            "label": "患者数・適格基準の充足分析",
+            "category": "application"
+          },
+          {
+            "id": "a2",
+            "label": "治験フィージビリティ評価",
+            "category": "outcome"
+          }
+        ],
+        "edges": [
+          {
+            "from": "s1",
+            "to": "p1",
+            "label": "標準化データ"
+          },
+          {
+            "from": "s2",
+            "to": "p1",
+            "label": "データ移動なし"
+          },
+          {
+            "from": "p1",
+            "to": "a1",
+            "label": "集計結果"
+          },
+          {
+            "from": "a1",
+            "to": "a2",
+            "label": "フィージビリティ判定"
+          }
+        ]
+      }
     }
   ],
   "status": "seed",

--- a/public/cases/da-0005/case.json
+++ b/public/cases/da-0005/case.json
@@ -35,19 +35,57 @@
       "type": "data_flow",
       "title": "FDA Sentinelのデータフロー",
       "note": "",
-      "nodes": [
-        { "id": "s1", "label": "米国の保険請求DB・電子健康記録", "category": "source" },
-        { "id": "s2", "label": "患者データの移動制約", "category": "constraint" },
-        { "id": "p1", "label": "標準化クエリのローカル実行", "category": "process" },
-        { "id": "a1", "label": "要約統計量の集約・分析", "category": "application" },
-        { "id": "a2", "label": "市販後医薬品安全性監視", "category": "outcome" }
-      ],
-      "edges": [
-        { "from": "s1", "to": "p1", "label": "Sentinel CDMデータ" },
-        { "from": "s2", "to": "p1", "label": "データ移動なし" },
-        { "from": "p1", "to": "a1", "label": "要約統計量" },
-        { "from": "a1", "to": "a2", "label": "安全性シグナル検出" }
-      ]
+      "data": {
+        "nodes": [
+          {
+            "id": "s1",
+            "label": "米国の保険請求DB・電子健康記録",
+            "category": "source"
+          },
+          {
+            "id": "s2",
+            "label": "患者データの移動制約",
+            "category": "constraint"
+          },
+          {
+            "id": "p1",
+            "label": "標準化クエリのローカル実行",
+            "category": "process"
+          },
+          {
+            "id": "a1",
+            "label": "要約統計量の集約・分析",
+            "category": "application"
+          },
+          {
+            "id": "a2",
+            "label": "市販後医薬品安全性監視",
+            "category": "outcome"
+          }
+        ],
+        "edges": [
+          {
+            "from": "s1",
+            "to": "p1",
+            "label": "Sentinel CDMデータ"
+          },
+          {
+            "from": "s2",
+            "to": "p1",
+            "label": "データ移動なし"
+          },
+          {
+            "from": "p1",
+            "to": "a1",
+            "label": "要約統計量"
+          },
+          {
+            "from": "a1",
+            "to": "a2",
+            "label": "安全性シグナル検出"
+          }
+        ]
+      }
     }
   ],
   "status": "seed",

--- a/public/cases/da-0006/case.json
+++ b/public/cases/da-0006/case.json
@@ -35,19 +35,57 @@
       "type": "data_flow",
       "title": "DataSHIELD/SOPHIAのデータフロー",
       "note": "",
-      "nodes": [
-        { "id": "s1", "label": "複数の肥満コホートデータ", "category": "source" },
-        { "id": "s2", "label": "個人データ移動の制約", "category": "constraint" },
-        { "id": "p1", "label": "DataSHIELDによる分散解析実行", "category": "process" },
-        { "id": "a1", "label": "肥満の層別化・バイオマーカー分析", "category": "application" },
-        { "id": "a2", "label": "大規模な層別化研究の実現", "category": "outcome" }
-      ],
-      "edges": [
-        { "from": "s1", "to": "p1", "label": "コホートデータ" },
-        { "from": "s2", "to": "p1", "label": "データ移動なし" },
-        { "from": "p1", "to": "a1", "label": "要約統計量" },
-        { "from": "a1", "to": "a2", "label": "層別化結果" }
-      ]
+      "data": {
+        "nodes": [
+          {
+            "id": "s1",
+            "label": "複数の肥満コホートデータ",
+            "category": "source"
+          },
+          {
+            "id": "s2",
+            "label": "個人データ移動の制約",
+            "category": "constraint"
+          },
+          {
+            "id": "p1",
+            "label": "DataSHIELDによる分散解析実行",
+            "category": "process"
+          },
+          {
+            "id": "a1",
+            "label": "肥満の層別化・バイオマーカー分析",
+            "category": "application"
+          },
+          {
+            "id": "a2",
+            "label": "大規模な層別化研究の実現",
+            "category": "outcome"
+          }
+        ],
+        "edges": [
+          {
+            "from": "s1",
+            "to": "p1",
+            "label": "コホートデータ"
+          },
+          {
+            "from": "s2",
+            "to": "p1",
+            "label": "データ移動なし"
+          },
+          {
+            "from": "p1",
+            "to": "a1",
+            "label": "要約統計量"
+          },
+          {
+            "from": "a1",
+            "to": "a2",
+            "label": "層別化結果"
+          }
+        ]
+      }
     }
   ],
   "status": "seed",

--- a/public/cases/da-0007/case.json
+++ b/public/cases/da-0007/case.json
@@ -35,19 +35,57 @@
       "type": "data_flow",
       "title": "DataSHIELDのデータフロー",
       "note": "",
-      "nodes": [
-        { "id": "s1", "label": "複数機関の研究データベース", "category": "source" },
-        { "id": "s2", "label": "個人データ共有の倫理的・法的制約", "category": "constraint" },
-        { "id": "p1", "label": "DataSHIELD/Opalで分散統計解析", "category": "process" },
-        { "id": "a1", "label": "マルチコホート研究の実施", "category": "application" },
-        { "id": "a2", "label": "100以上の研究で活用実績", "category": "outcome" }
-      ],
-      "edges": [
-        { "from": "s1", "to": "p1", "label": "各施設のデータ" },
-        { "from": "s2", "to": "p1", "label": "データ非移動" },
-        { "from": "p1", "to": "a1", "label": "集約統計結果" },
-        { "from": "a1", "to": "a2", "label": "研究成果" }
-      ]
+      "data": {
+        "nodes": [
+          {
+            "id": "s1",
+            "label": "複数機関の研究データベース",
+            "category": "source"
+          },
+          {
+            "id": "s2",
+            "label": "個人データ共有の倫理的・法的制約",
+            "category": "constraint"
+          },
+          {
+            "id": "p1",
+            "label": "DataSHIELD/Opalで分散統計解析",
+            "category": "process"
+          },
+          {
+            "id": "a1",
+            "label": "マルチコホート研究の実施",
+            "category": "application"
+          },
+          {
+            "id": "a2",
+            "label": "100以上の研究で活用実績",
+            "category": "outcome"
+          }
+        ],
+        "edges": [
+          {
+            "from": "s1",
+            "to": "p1",
+            "label": "各施設のデータ"
+          },
+          {
+            "from": "s2",
+            "to": "p1",
+            "label": "データ非移動"
+          },
+          {
+            "from": "p1",
+            "to": "a1",
+            "label": "集約統計結果"
+          },
+          {
+            "from": "a1",
+            "to": "a2",
+            "label": "研究成果"
+          }
+        ]
+      }
     }
   ],
   "status": "seed",

--- a/public/cases/da-0008/case.json
+++ b/public/cases/da-0008/case.json
@@ -35,19 +35,57 @@
       "type": "data_flow",
       "title": "Personal Health Trainのデータフロー",
       "note": "",
-      "nodes": [
-        { "id": "s1", "label": "各施設の医療データ（「駅」）", "category": "source" },
-        { "id": "s2", "label": "データ移動の制約", "category": "constraint" },
-        { "id": "p1", "label": "解析タスク（「列車」）を各駅に配送", "category": "process" },
-        { "id": "a1", "label": "分散型機械学習・統計解析", "category": "application" },
-        { "id": "a2", "label": "FAIR原則と個人情報保護の両立", "category": "outcome" }
-      ],
-      "edges": [
-        { "from": "s1", "to": "p1", "label": "データは駅に保持" },
-        { "from": "s2", "to": "p1", "label": "アルゴリズム移動" },
-        { "from": "p1", "to": "a1", "label": "分散解析結果" },
-        { "from": "a1", "to": "a2", "label": "研究成果" }
-      ]
+      "data": {
+        "nodes": [
+          {
+            "id": "s1",
+            "label": "各施設の医療データ（「駅」）",
+            "category": "source"
+          },
+          {
+            "id": "s2",
+            "label": "データ移動の制約",
+            "category": "constraint"
+          },
+          {
+            "id": "p1",
+            "label": "解析タスク（「列車」）を各駅に配送",
+            "category": "process"
+          },
+          {
+            "id": "a1",
+            "label": "分散型機械学習・統計解析",
+            "category": "application"
+          },
+          {
+            "id": "a2",
+            "label": "FAIR原則と個人情報保護の両立",
+            "category": "outcome"
+          }
+        ],
+        "edges": [
+          {
+            "from": "s1",
+            "to": "p1",
+            "label": "データは駅に保持"
+          },
+          {
+            "from": "s2",
+            "to": "p1",
+            "label": "アルゴリズム移動"
+          },
+          {
+            "from": "p1",
+            "to": "a1",
+            "label": "分散解析結果"
+          },
+          {
+            "from": "a1",
+            "to": "a2",
+            "label": "研究成果"
+          }
+        ]
+      }
     }
   ],
   "status": "seed",

--- a/public/cases/da-0009/case.json
+++ b/public/cases/da-0009/case.json
@@ -35,19 +35,57 @@
       "type": "data_flow",
       "title": "PHT-meDICのデータフロー",
       "note": "",
-      "nodes": [
-        { "id": "s1", "label": "ドイツ全国の大学病院データ", "category": "source" },
-        { "id": "s2", "label": "病院間のデータ移動制約", "category": "constraint" },
-        { "id": "p1", "label": "PHT-meDICで解析コンテナを分散実行", "category": "process" },
-        { "id": "a1", "label": "全国規模の臨床研究実施", "category": "application" },
-        { "id": "a2", "label": "COVID-19対応含む迅速な研究遂行", "category": "outcome" }
-      ],
-      "edges": [
-        { "from": "s1", "to": "p1", "label": "FHIRで標準化" },
-        { "from": "s2", "to": "p1", "label": "コンテナのみ移動" },
-        { "from": "p1", "to": "a1", "label": "分散解析結果" },
-        { "from": "a1", "to": "a2", "label": "研究成果" }
-      ]
+      "data": {
+        "nodes": [
+          {
+            "id": "s1",
+            "label": "ドイツ全国の大学病院データ",
+            "category": "source"
+          },
+          {
+            "id": "s2",
+            "label": "病院間のデータ移動制約",
+            "category": "constraint"
+          },
+          {
+            "id": "p1",
+            "label": "PHT-meDICで解析コンテナを分散実行",
+            "category": "process"
+          },
+          {
+            "id": "a1",
+            "label": "全国規模の臨床研究実施",
+            "category": "application"
+          },
+          {
+            "id": "a2",
+            "label": "COVID-19対応含む迅速な研究遂行",
+            "category": "outcome"
+          }
+        ],
+        "edges": [
+          {
+            "from": "s1",
+            "to": "p1",
+            "label": "FHIRで標準化"
+          },
+          {
+            "from": "s2",
+            "to": "p1",
+            "label": "コンテナのみ移動"
+          },
+          {
+            "from": "p1",
+            "to": "a1",
+            "label": "分散解析結果"
+          },
+          {
+            "from": "a1",
+            "to": "a2",
+            "label": "研究成果"
+          }
+        ]
+      }
     }
   ],
   "status": "seed",

--- a/public/cases/da-0010/case.json
+++ b/public/cases/da-0010/case.json
@@ -35,19 +35,57 @@
       "type": "data_flow",
       "title": "京都大学・大阪大学等のデータフロー",
       "note": "",
-      "nodes": [
-        { "id": "s1", "label": "各大学病院のリアルワールドデータ", "category": "source" },
-        { "id": "s2", "label": "個人情報保護と施設間データ共有制約", "category": "constraint" },
-        { "id": "p1", "label": "PHT型で解析コードを各施設に配布実行", "category": "process" },
-        { "id": "a1", "label": "多施設共同臨床研究", "category": "application" },
-        { "id": "a2", "label": "RWD二次利用と個人情報保護の両立", "category": "outcome" }
-      ],
-      "edges": [
-        { "from": "s1", "to": "p1", "label": "各施設のRWD" },
-        { "from": "s2", "to": "p1", "label": "データ非移動" },
-        { "from": "p1", "to": "a1", "label": "分散解析結果" },
-        { "from": "a1", "to": "a2", "label": "研究成果" }
-      ]
+      "data": {
+        "nodes": [
+          {
+            "id": "s1",
+            "label": "各大学病院のリアルワールドデータ",
+            "category": "source"
+          },
+          {
+            "id": "s2",
+            "label": "個人情報保護と施設間データ共有制約",
+            "category": "constraint"
+          },
+          {
+            "id": "p1",
+            "label": "PHT型で解析コードを各施設に配布実行",
+            "category": "process"
+          },
+          {
+            "id": "a1",
+            "label": "多施設共同臨床研究",
+            "category": "application"
+          },
+          {
+            "id": "a2",
+            "label": "RWD二次利用と個人情報保護の両立",
+            "category": "outcome"
+          }
+        ],
+        "edges": [
+          {
+            "from": "s1",
+            "to": "p1",
+            "label": "各施設のRWD"
+          },
+          {
+            "from": "s2",
+            "to": "p1",
+            "label": "データ非移動"
+          },
+          {
+            "from": "p1",
+            "to": "a1",
+            "label": "分散解析結果"
+          },
+          {
+            "from": "a1",
+            "to": "a2",
+            "label": "研究成果"
+          }
+        ]
+      }
     }
   ],
   "status": "seed",

--- a/public/cases/da-0011/case.json
+++ b/public/cases/da-0011/case.json
@@ -35,19 +35,57 @@
       "type": "data_flow",
       "title": "AMED CANNDsのデータフロー",
       "note": "",
-      "nodes": [
-        { "id": "s1", "label": "BBJ・ToMMo等のゲノムコホートデータ", "category": "source" },
-        { "id": "s2", "label": "ゲノムデータの機微性と移動制約", "category": "constraint" },
-        { "id": "p1", "label": "CANNDs基盤で分散処理解析を実行", "category": "process" },
-        { "id": "a1", "label": "バイオバンク横断ゲノム解析", "category": "application" },
-        { "id": "a2", "label": "数十万人規模のゲノム研究加速", "category": "outcome" }
-      ],
-      "edges": [
-        { "from": "s1", "to": "p1", "label": "各バイオバンクのデータ" },
-        { "from": "s2", "to": "p1", "label": "データ非移動" },
-        { "from": "p1", "to": "a1", "label": "分散処理結果" },
-        { "from": "a1", "to": "a2", "label": "研究成果" }
-      ]
+      "data": {
+        "nodes": [
+          {
+            "id": "s1",
+            "label": "BBJ・ToMMo等のゲノムコホートデータ",
+            "category": "source"
+          },
+          {
+            "id": "s2",
+            "label": "ゲノムデータの機微性と移動制約",
+            "category": "constraint"
+          },
+          {
+            "id": "p1",
+            "label": "CANNDs基盤で分散処理解析を実行",
+            "category": "process"
+          },
+          {
+            "id": "a1",
+            "label": "バイオバンク横断ゲノム解析",
+            "category": "application"
+          },
+          {
+            "id": "a2",
+            "label": "数十万人規模のゲノム研究加速",
+            "category": "outcome"
+          }
+        ],
+        "edges": [
+          {
+            "from": "s1",
+            "to": "p1",
+            "label": "各バイオバンクのデータ"
+          },
+          {
+            "from": "s2",
+            "to": "p1",
+            "label": "データ非移動"
+          },
+          {
+            "from": "p1",
+            "to": "a1",
+            "label": "分散処理結果"
+          },
+          {
+            "from": "a1",
+            "to": "a2",
+            "label": "研究成果"
+          }
+        ]
+      }
     }
   ],
   "status": "seed",


### PR DESCRIPTION
## Summary
- da-0001〜da-0011のcase.jsonで、`figures`配列内の`nodes`/`edges`がトップレベルに配置されていたため、`FigureRenderer`が`figure.data`を`undefined`として受け取りページが真っ白になっていた問題を修正
- `nodes`/`edges`を`data`オブジェクト内にネストし、他の事例と同じ構造に統一

## Test plan
- [ ] https://pwscup.github.io/syntheticdata-usecase-catalog/#/cases/da-0005 でページが正常に表示されることを確認
- [ ] da-0001〜da-0011の全ページで概要図（data_flow）が表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)