### PR TITLE
fix: 概要図の列ラベルを「収集・PETs適用・価値創出」に変更

### DIFF
--- a/src/__tests__/FigureRenderer.test.tsx
+++ b/src/__tests__/FigureRenderer.test.tsx
@@ -24,8 +24,8 @@ describe('FigureRenderer', () => {
     expect(screen.getByText('データフロー図')).toBeInTheDocument()
     // 3列ヘッダー
     expect(screen.getByText('収集')).toBeInTheDocument()
-    expect(screen.getByText('合成')).toBeInTheDocument()
-    expect(screen.getByText('活用')).toBeInTheDocument()
+    expect(screen.getByText('PETs適用')).toBeInTheDocument()
+    expect(screen.getByText('価値創出')).toBeInTheDocument()
     // ノードラベル
     expect(screen.getByText('元データ')).toBeInTheDocument()
     expect(screen.getByText('プライバシー制約')).toBeInTheDocument()

--- a/src/components/figures/DataFlowDiagram.tsx
+++ b/src/components/figures/DataFlowDiagram.tsx
@@ -16,7 +16,7 @@ const COLUMN_CONFIG = [
   },
   {
     key: 'generate',
-    label: '合成',
+    label: 'PETs適用',
     categories: ['process'],
     bgClass: 'bg-indigo-50',
     arrowClass: 'bg-indigo-700',
@@ -24,7 +24,7 @@ const COLUMN_CONFIG = [
   },
   {
     key: 'utilize',
-    label: '活用',
+    label: '価値創出',
     categories: ['application', 'outcome'],
     bgClass: 'bg-emerald-50',
     arrowClass: 'bg-emerald-700',


### PR DESCRIPTION
## Summary
- 概要図（DataFlowDiagram）の3列ラベルを「収集・合成・活用」→「収集・PETs適用・価値創出」に変更
- 「合成」は合成データ以外の事例（分散データ分析等）では不適切なため、技術カテゴリに依存しない汎用的なラベルに修正

## Test plan
- [ ] 各事例の概要図で「収集」「PETs適用」「価値創出」のラベルが正しく表示されることを確認
- [ ] FigureRenderer.test.tsx のテストが通ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)