### PR TITLE
feat: Playwright E2Eテストの追加

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,3 +25,9 @@ jobs:
 
       - name: Run tests
         run: npx vitest run
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium
+
+      - name: Run E2E tests
+        run: npx playwright test

--- a/e2e/cases.spec.ts
+++ b/e2e/cases.spec.ts
@@ -1,0 +1,222 @@
+import { test, expect } from '@playwright/test'
+
+// ------------------------------------------------------------------
+// E2E: 事例一覧ページの基本表示
+// ------------------------------------------------------------------
+test.describe('事例一覧ページ', () => {
+  test('一覧ページが表示され、事例カードが1件以上ある', async ({ page }) => {
+    await page.goto('/')
+    // 「読み込み中...」が消えるのを待つ
+    await expect(page.locator('text=読み込み中')).toBeHidden({ timeout: 15_000 })
+    // エラー表示がないこと
+    await expect(page.locator('text=エラー')).toBeHidden()
+    // カードが1件以上表示される (CaseCard は <a> でラップされ h2 にタイトル)
+    const cards = page.locator('a h2')
+    await expect(cards.first()).toBeVisible()
+    expect(await cards.count()).toBeGreaterThan(0)
+  })
+
+  test('件数表示が「件の事例」を含む', async ({ page }) => {
+    await page.goto('/')
+    await expect(page.locator('text=読み込み中')).toBeHidden({ timeout: 15_000 })
+    await expect(page.locator('text=件の事例')).toBeVisible()
+  })
+
+  test('コンソールエラーが発生しない', async ({ page }) => {
+    const errors: string[] = []
+    page.on('console', (msg) => {
+      if (msg.type() === 'error') errors.push(msg.text())
+    })
+    await page.goto('/')
+    await expect(page.locator('text=読み込み中')).toBeHidden({ timeout: 15_000 })
+    expect(errors).toEqual([])
+  })
+})
+
+// ------------------------------------------------------------------
+// E2E: 全事例の詳細ページが壊れずに表示される
+// ------------------------------------------------------------------
+test.describe('全事例の詳細ページ', () => {
+  let caseIds: string[] = []
+
+  test.beforeAll(async ({ request }) => {
+    const res = await request.get('/cases/index.json')
+    expect(res.ok()).toBe(true)
+    const data = await res.json()
+    caseIds = data.cases ?? data
+    expect(caseIds.length).toBeGreaterThan(0)
+  })
+
+  test('index.json の全事例IDの詳細ページが表示できる', async ({ page }) => {
+    test.setTimeout(120_000)
+    const failures: { id: string; reason: string }[] = []
+    const errors: { id: string; message: string }[] = []
+
+    page.on('console', (msg) => {
+      if (msg.type() === 'error') {
+        errors.push({ id: 'pending', message: msg.text() })
+      }
+    })
+
+    for (const id of caseIds) {
+      // コンソールエラーのトラッキング用にIDを設定
+      errors.forEach((e) => {
+        if (e.id === 'pending') e.id = id
+      })
+
+      await page.goto(`/#/cases/${id}`)
+      // 読み込み完了を待つ
+      await expect(page.locator('text=読み込み中')).toBeHidden({ timeout: 15_000 })
+
+      // 「事例が見つかりません」が表示されていないこと
+      const notFound = page.locator('text=事例が見つかりません')
+      if (await notFound.isVisible().catch(() => false)) {
+        failures.push({ id, reason: '事例が見つかりません' })
+        continue
+      }
+
+      // タイトル (h1 or h2) が表示されていること
+      const title = page.locator('h1, h2').first()
+      if (!(await title.isVisible().catch(() => false))) {
+        failures.push({ id, reason: 'タイトルが表示されない' })
+        continue
+      }
+
+      // 「一覧に戻る」リンクが存在すること（詳細ページの証拠）
+      const backLink = page.locator('text=一覧に戻る')
+      if (!(await backLink.isVisible().catch(() => false))) {
+        failures.push({ id, reason: '一覧に戻るリンクがない' })
+      }
+    }
+
+    if (failures.length > 0) {
+      console.log('--- 表示に失敗した事例 ---')
+      failures.forEach((f) => console.log(`  ${f.id}: ${f.reason}`))
+    }
+    expect(failures).toEqual([])
+  })
+
+  test('全事例の詳細ページでコンソールエラーが発生しない', async ({ page }) => {
+    test.setTimeout(120_000)
+    const caseErrors: { id: string; message: string }[] = []
+
+    for (const id of caseIds) {
+      const pageErrors: string[] = []
+      const handler = (msg: import('@playwright/test').ConsoleMessage) => {
+        if (msg.type() === 'error') pageErrors.push(msg.text())
+      }
+      page.on('console', handler)
+
+      await page.goto(`/#/cases/${id}`)
+      await expect(page.locator('text=読み込み中')).toBeHidden({ timeout: 15_000 })
+
+      page.off('console', handler)
+
+      for (const msg of pageErrors) {
+        caseErrors.push({ id, message: msg })
+      }
+    }
+
+    if (caseErrors.length > 0) {
+      console.log('--- コンソールエラーが発生した事例 ---')
+      caseErrors.forEach((e) => console.log(`  ${e.id}: ${e.message}`))
+    }
+    expect(caseErrors).toEqual([])
+  })
+})
+
+// ------------------------------------------------------------------
+// E2E: ナビゲーション
+// ------------------------------------------------------------------
+test.describe('ナビゲーション', () => {
+  test('一覧 → 詳細 → 一覧に戻る が動作する', async ({ page }) => {
+    await page.goto('/')
+    await expect(page.locator('text=読み込み中')).toBeHidden({ timeout: 15_000 })
+
+    // 最初のカードをクリック
+    const firstCard = page.locator('a h2').first()
+    const cardTitle = await firstCard.textContent()
+    await firstCard.click()
+
+    // 詳細ページでタイトルが表示される
+    await expect(page.locator('text=一覧に戻る')).toBeVisible()
+
+    // 一覧に戻る
+    await page.locator('text=一覧に戻る').first().click()
+    await expect(page.locator('text=件の事例')).toBeVisible()
+  })
+
+  test('Aboutページが表示される', async ({ page }) => {
+    await page.goto('/#/about')
+    await expect(page.locator('h1, h2').first()).toBeVisible()
+  })
+
+  test('統計ページが表示される', async ({ page }) => {
+    await page.goto('/#/stats')
+    await expect(page.locator('text=読み込み中')).toBeHidden({ timeout: 15_000 })
+    await expect(page.locator('text=エラー')).toBeHidden()
+  })
+})
+
+// ------------------------------------------------------------------
+// E2E: case.json の構造検証（ランタイム）
+// ------------------------------------------------------------------
+test.describe('case.json データ整合性', () => {
+  test('全事例の case.json が必須フィールドを持つ', async ({ request }) => {
+    const res = await request.get('/cases/index.json')
+    const data = await res.json()
+    const caseIds: string[] = data.cases ?? data
+
+    const failures: { id: string; missing: string[] }[] = []
+    const requiredFields = ['id', 'title', 'domain', 'organization', 'summary', 'sources', 'figures']
+
+    for (const id of caseIds) {
+      const caseRes = await request.get(`/cases/${id}/case.json`)
+      expect(caseRes.ok()).toBe(true)
+
+      const data = await caseRes.json()
+      const missing = requiredFields.filter((f) => !(f in data) || data[f] === undefined || data[f] === null)
+      if (missing.length > 0) {
+        failures.push({ id, missing })
+      }
+    }
+
+    if (failures.length > 0) {
+      console.log('--- 必須フィールド不足の事例 ---')
+      failures.forEach((f) => console.log(`  ${f.id}: ${f.missing.join(', ')}`))
+    }
+    expect(failures).toEqual([])
+  })
+
+  test('全事例の figures.data が nodes/edges 構造を持つ', async ({ request }) => {
+    const res = await request.get('/cases/index.json')
+    const data = await res.json()
+    const caseIds: string[] = data.cases ?? data
+
+    const failures: { id: string; reason: string }[] = []
+
+    for (const id of caseIds) {
+      const caseRes = await request.get(`/cases/${id}/case.json`)
+      const data = await caseRes.json()
+
+      if (!Array.isArray(data.figures)) continue
+
+      for (const fig of data.figures) {
+        if (fig.type === 'data_flow') {
+          if (!fig.data || !Array.isArray(fig.data.nodes)) {
+            failures.push({ id, reason: `data_flow figure missing data.nodes` })
+          }
+          if (!fig.data || !Array.isArray(fig.data.edges)) {
+            failures.push({ id, reason: `data_flow figure missing data.edges` })
+          }
+        }
+      }
+    }
+
+    if (failures.length > 0) {
+      console.log('--- figures構造が不正な事例 ---')
+      failures.forEach((f) => console.log(`  ${f.id}: ${f.reason}`))
+    }
+    expect(failures).toEqual([])
+  })
+})

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "syntheticdata-usecase-catalog-tmp",
-  "version": "0.0.0",
+  "name": "syntheticdata-usecase-catalog",
+  "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "syntheticdata-usecase-catalog-tmp",
-      "version": "0.0.0",
+      "name": "syntheticdata-usecase-catalog",
+      "version": "0.1.0",
       "dependencies": {
         "@hookform/resolvers": "^5.2.2",
         "react": "^19.2.0",
@@ -17,6 +17,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.39.1",
+        "@playwright/test": "^1.58.2",
         "@tailwindcss/vite": "^4.2.1",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
@@ -1276,6 +1277,22 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.58.2.tgz",
+      "integrity": "sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.58.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@rolldown/pluginutils": {
@@ -4248,6 +4265,53 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.2.tgz",
+      "integrity": "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.58.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.2.tgz",
+      "integrity": "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/postcss": {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,9 @@
     "validate": "tsx scripts/validate-cases.ts",
     "test": "vitest run",
     "test:watch": "vitest",
-    "test:coverage": "vitest run --coverage"
+    "test:coverage": "vitest run --coverage",
+    "test:e2e": "playwright test",
+    "test:e2e:ui": "playwright test --ui"
   },
   "dependencies": {
     "@hookform/resolvers": "^5.2.2",
@@ -23,6 +25,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.39.1",
+    "@playwright/test": "^1.58.2",
     "@tailwindcss/vite": "^4.2.1",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,23 @@
+import { defineConfig } from '@playwright/test'
+
+export default defineConfig({
+  testDir: './e2e',
+  timeout: 30_000,
+  retries: 0,
+  use: {
+    baseURL: 'http://localhost:4173',
+    headless: true,
+  },
+  webServer: {
+    command: 'npm run build && npm run preview -- --port 4173',
+    port: 4173,
+    reuseExistingServer: !process.env.CI,
+    timeout: 60_000,
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { browserName: 'chromium' },
+    },
+  ],
+})


### PR DESCRIPTION
## Summary
- Playwright による E2E テストを導入し、事例ページの破損を CI で自動検出
- 全95件の事例詳細ページを巡回し、表示エラー・コンソールエラー・データ構造の不整合を検証
- CI ワークフロー（`.github/workflows/ci.yml`）に E2E テストステップを追加

## 背景
過去に事例を追加した際、ページが壊れているのに気づかずPRをマージしてしまった事例があった。ユニットテストだけでは検出できないランタイムの表示崩れを防止するため、E2E テストを導入する。

## テスト内容（10件）

| カテゴリ | テスト | 検出する問題 |
|---|---|---|
| 一覧ページ | カード表示・件数表示・コンソールエラー | ビルド破損、データ読み込み失敗 |
| 全事例詳細 | 全ID巡回・表示確認・コンソールエラー | case.json 追加/変更による詳細ページ破損 |
| ナビゲーション | 一覧↔詳細遷移、About、Stats | ルーティング破損 |
| データ整合性 | 必須フィールド検証、figures構造検証 | フィールド欠損、figures構造の不整合（#55 の再発防止） |

## Test plan
- [x] ローカルで `npm run test:e2e` を実行し、全10テストがパスすることを確認済み（11.7秒）
- [ ] CI（GitHub Actions）での実行を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)