### PR TITLE
feat: GitHubリポジトリへのリンクを追加

### DIFF
--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -11,6 +11,15 @@ export default function Footer() {
       </p>
       <p className="text-gray-400 text-xs">
         &copy; 2026 合成データ ユースケースカタログ
+        <span className="mx-1">|</span>
+        <a
+          href="https://github.com/pwscup/syntheticdata-usecase-catalog"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-blue-500 hover:text-blue-600 underline underline-offset-2"
+        >
+          GitHub
+        </a>
       </p>
     </footer>
   )

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -12,6 +12,15 @@ export default function Header() {
           <Link to="/cases/new" className="hover:underline">新規作成</Link>
           <Link to="/settings" className="hover:underline">設定</Link>
           <Link to="/about" className="hover:underline">About</Link>
+          <a
+            href="https://github.com/pwscup/syntheticdata-usecase-catalog"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="hover:underline flex items-center gap-1"
+          >
+            <svg className="w-4 h-4" fill="currentColor" viewBox="0 0 16 16"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27s1.36.09 2 .27c1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0016 8c0-4.42-3.58-8-8-8z"/></svg>
+            GitHub
+          </a>
         </nav>
       </div>
     </header>


### PR DESCRIPTION
## Summary
- ヘッダーナビにGitHubアイコン付きリンクを追加
- フッターにもGitHubリポジトリリンクを追加
- 開発者・コントリビュータがトップページからリポジトリに遷移可能に

Closes #57

## Test plan
- [ ] ヘッダーのGitHubリンクをクリックしてリポジトリページが開くことを確認
- [ ] フッターのGitHubリンクをクリックしてリポジトリページが開くことを確認
- [ ] リンクが新しいタブで開くことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)