### PR TITLE
feat: Claude Code設定の整備 - CLAUDE.md・スキル・エージェント

### DIFF
--- a/.claude/agents/case-reviewer.md
+++ b/.claude/agents/case-reviewer.md
@@ -1,0 +1,123 @@
+---
+name: case-reviewer
+description: case.json の品質・整合性を自律的にレビューするエージェント。事例追加・更新後のレビューに使用。
+tools: Read, Grep, Glob, Bash, WebFetch, WebSearch
+model: sonnet
+---
+
+# Role
+
+You are a case.json quality reviewer for a PETs (Privacy Enhancing Technologies) use case catalog. Your job is to verify that each case accurately reflects its source material and conforms to the project schema.
+
+# Review Process
+
+## 1. Identify Target Cases
+
+- If case IDs or file paths are provided, review those specific cases.
+- If none specified, find recently modified cases via `git diff --name-only HEAD~5 -- 'public/cases/*/case.json'` or review all cases under `public/cases/`.
+
+## 2. Read and Parse Each case.json
+
+- Read the file at `public/cases/{id}/case.json`.
+- Verify all required fields are present per the schema:
+  - `id`, `title`, `region`, `domain`, `organization`, `usecase_category`, `technology_category`, `review_status`, `summary`, `value_proposition`, `privacy_enhancement_method`, `safety_assurance_method`, `utility_evaluation_method`, `tags`, `sources` (min 1), `figures`, `status`, `created_at`, `updated_at`
+
+## 3. Verify Sources
+
+- Fetch **every** URL in `sources[]` using WebFetch.
+- Confirm each URL is accessible. If not, flag it.
+- Note what each source covers -- which claims in the case it supports.
+
+## 4. Apply Three Review Perspectives
+
+### a. Fact-Checker
+
+- Cross-check every factual claim in the case against the source material.
+- Verify the subject (who did what) is accurate -- distinguish between vendor, customer, research partner, and announcing entity.
+- Verify relationships between organizations are explicitly stated in sources, not inferred.
+- Verify dates align with source publication dates.
+
+### b. Business Reviewer
+
+- Check that implementation stage language is precise: distinguish "planning/considering" from "deployed/operational".
+- Check `value_proposition` does not overstate what sources confirm.
+- Verify outcomes are actual results, not future expectations presented as achievements.
+- Confirm the case is a coherent single use case, not multiple cases merged or a generic company profile forced into case format.
+
+### c. PETs Technical Reviewer
+
+- Verify `technology_category` matches the actual technique described in sources.
+  - Valid values: `synthetic_data`, `differential_privacy`, `anonymization`, `federated_learning`, `secure_computation`, `distributed_analytics`
+- Distinguish anonymization vs. pseudonymization (Japanese law: 匿名加工情報 vs. 仮名加工情報).
+- For synthetic_data, confirm if it is used for privacy protection or data augmentation.
+- Do not add technology terms not present in the source material.
+
+## 5. Validate Domain and Categories
+
+- `domain` must match the case's primary industry sector.
+  - Valid domains: 金融, 医療, 公共, 通信, モビリティ, IT, エネルギー, 小売, 製造
+  - Use the subject organization's sector, not a generic technology category.
+- `usecase_category` should reflect the actual use pattern:
+  - Valid values: 組織内データ共有, 組織間データ共有, 外部分析者活用, R&D, データ販売, フィージビリティ検証, 公的利用
+- `region` must be 国内 or 国外.
+
+## 6. Validate Figures
+
+- For `data_flow` figures: confirm node labels and edges reflect source-verifiable information. No invented causal relationships.
+- Confirm `category` on nodes is appropriate (source / constraint / process / application / outcome).
+
+# Key Review Rules (Strict)
+
+1. **Do not infer unstated relationships.** Even if a connection seems obvious, if the source does not explicitly state it, flag it.
+2. **Preserve weak language.** "検討中" (considering) is not "導入済み" (deployed). "目指す" (aiming for) is not "実現" (achieved). "可能にする" (enables) is not "達成した" (accomplished).
+3. **No evidence = "根拠不足" (insufficient evidence).** Do not call it correct or incorrect -- mark it as unverifiable.
+4. **Do not fill gaps with domain knowledge.** Missing information stays missing.
+5. **Source-only evaluation.** Judge solely from the URLs in `sources[]`. Do not supplement with external knowledge.
+6. **Watch for common errors:**
+   - anonymization / pseudonymization confusion (匿名化 vs. 仮名化)
+   - domain misclassification (using generic tech category instead of industry)
+   - vendor capability described as case-specific implementation
+   - implementation stage inflation (検討 -> 導入)
+   - policy-level sources treated as evidence of actual deployment
+   - missing organizations from joint announcements
+   - future expectations written as past achievements
+
+# Output Format
+
+For each case reviewed, output:
+
+```markdown
+## Review: {case_id} - {title}
+
+### Verdict: PASS | NEEDS_REVISION | FAIL
+
+### Summary
+(2-4 sentences on overall quality)
+
+### Source Verification
+| URL | Accessible | Covers | Notes |
+|-----|-----------|--------|-------|
+
+### Field Assessment
+| Field | Status | Issue | Suggested Fix |
+|-------|--------|-------|---------------|
+
+Status: OK / CONCERN / NEEDS_FIX
+
+### Critical Issues
+(Issues that MUST be fixed before publishing. Empty if none.)
+
+### Suggested Improvements
+(Optional quality improvements. Not blockers.)
+```
+
+Verdict criteria:
+- **PASS**: All fields accurate, sources accessible, no factual errors.
+- **NEEDS_REVISION**: Minor inaccuracies, missing fields, or unverifiable claims that can be corrected.
+- **FAIL**: Major factual errors, inaccessible sources with no alternatives, fabricated relationships, or fundamentally flawed case structure.
+
+# Workflow
+
+1. Identify cases to review.
+2. For each case, read the JSON, fetch all sources, apply the three review perspectives, and produce the output.
+3. After reviewing all cases, provide a summary count: N reviewed, N PASS, N NEEDS_REVISION, N FAIL.

--- a/.claude/skills/case-create/SKILL.md
+++ b/.claude/skills/case-create/SKILL.md
@@ -1,0 +1,57 @@
+---
+name: case-create
+description: 文献URL・テキストから新規 case.json を作成
+argument-hint: "<URL or description of literature>"
+user-invocable: true
+---
+
+提供された文献（URL またはテキスト）から合成データ活用事例の case.json を新規作成する。
+
+## 手順
+
+### 1. 文献の取得・読み取り
+
+$ARGUMENTS で指定された URL を WebFetch で取得する。テキストが直接与えられた場合はそのまま使用する。
+
+### 2. 事例情報の抽出
+
+`src/constants/prompts.ts` の `generateCreatePrompt()` に定義されたガイドラインに従い、文献から以下の情報を抽出する:
+
+- title, summary, value_proposition
+- region, domain, domain_sub, organization
+- usecase_category（選択肢は `src/constants/categories.ts` を参照）
+- privacy_enhancement_method, safety_assurance_method, utility_evaluation_method
+- tags, sources
+- figures（data_flow のノードとエッジ）
+
+**重要**: フィールドごとの記入ガイドライン（title の文字数目安、summary の構造、data_flow ノードの命名規則など）は `src/constants/prompts.ts` を正とする。文献から読み取れない項目は「調査中」と記入し、推測で埋めない。
+
+### 3. case.json の生成
+
+スキーマは `src/schemas/case.schema.ts` に定義されている。スキーマに適合する JSON を生成する。
+
+事例 ID は既存の `public/cases/` 配下の ID を確認し、連番で次の ID を採番する（例: 既存が `001`〜`045` なら `046`）。
+
+### 4. ファイルの保存
+
+```bash
+mkdir -p public/cases/<id>
+```
+
+生成した JSON を `public/cases/<id>/case.json` に保存する。
+
+### 5. index.json の更新
+
+`public/cases/index.json` に新しい事例 ID を追加する。
+
+### 6. バリデーション
+
+```bash
+npx tsx scripts/validate-cases.ts
+```
+
+エラーがあれば修正して再度バリデーションを実行する。
+
+### 7. レビュー
+
+生成した事例に対して /case-review を実行し、公開情報との整合性を検証する。

--- a/.claude/skills/case-enrich/SKILL.md
+++ b/.claude/skills/case-enrich/SKILL.md
@@ -1,0 +1,51 @@
+---
+name: case-enrich
+description: 追加文献で既存事例の case.json を補完・改善
+argument-hint: "<case-id> <URL or description>"
+user-invocable: true
+---
+
+追加文献をもとに既存の case.json を補完・改善する。
+
+## 手順
+
+### 1. 引数の解析
+
+$ARGUMENTS の最初のトークンを事例 ID、残りを文献ソースとして扱う。
+
+- 例: `045 https://example.com/report.pdf` → ID=`045`, 文献=`https://example.com/report.pdf`
+
+### 2. 既存 case.json の読み込み
+
+```
+public/cases/<case-id>/case.json
+```
+
+ファイルが存在しない場合はエラーを報告して終了する。
+
+### 3. 追加文献の取得・読み取り
+
+URL が指定された場合は WebFetch で取得する。テキストが直接与えられた場合はそのまま使用する。
+
+### 4. case.json の更新
+
+`src/constants/prompts.ts` の `generateEnrichPrompt()` に定義された作業ルールに従い、既存の case.json を更新する。主なルール:
+
+- **すべての項目が改善対象**: 「調査中」の項目だけでなく、より正確・詳細・具体的にできる項目も更新する
+- **sources の追加**: 追加文献を sources 配列に追記する（既存の source は削除しない）
+- **推測しない**: 文献に明記されていない情報は既存の記載を維持する
+- **data_flow の改善**: ノードの label をより具体的にできる場合は更新する（手法名、数値など）
+
+詳細なガイドラインは `src/constants/prompts.ts` を正とする。
+
+### 5. バリデーション
+
+```bash
+npx tsx scripts/validate-cases.ts
+```
+
+エラーがあれば修正して再度バリデーションを実行する。
+
+### 6. レビュー
+
+更新した事例に対して /case-review を実行し、公開情報との整合性を検証する。

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,74 @@
+# PETs活用事例カタログ
+
+プライバシー強化技術（PETs）の実世界活用事例を収集・整理・検索できるWebカタログ。
+
+## 技術スタック
+
+React 19 + TypeScript + Vite + Tailwind CSS v4 + React Router v7 + Zod
+
+テスト: Vitest + Testing Library（単体）、Playwright（E2E）
+デプロイ: GitHub Pages（mainプッシュで自動デプロイ）
+
+## コマンド
+
+```
+npm run dev          # 開発サーバー起動
+npm run build        # 本番ビルド (tsc + vite build)
+npm run test         # 単体テスト (vitest run)
+npm run test:e2e     # E2Eテスト (playwright)
+npm run lint         # ESLint
+npm run validate     # case.json バリデーション
+```
+
+## ディレクトリ構成
+
+```
+src/
+├── pages/           # ページコンポーネント（List, Detail, New, Edit, Stats, About）
+├── components/      # UIコンポーネント（case-list, case-detail, case-form, figures）
+├── schemas/         # Zodバリデーションスキーマ (case.schema.ts)
+├── types/           # TypeScript型定義 (case.ts)
+├── constants/       # 定数（categories, styles, prompts）
+├── context/         # CaseContext（データ提供）
+├── hooks/           # useFilter（フィルタ・ソート）
+├── lib/             # ユーティリティ（data-loader, import-case）
+└── __tests__/       # 単体テスト
+
+public/cases/        # 事例データ（1ディレクトリ = 1事例）
+├── index.json       # 事例ID一覧（ビルド時に自動生成）
+└── <id>/case.json   # 個別事例データ
+
+scripts/             # validate-cases.ts 等のCLIスクリプト
+e2e/                 # Playwright E2Eテスト
+```
+
+## ブランチ戦略
+
+- `main`: 本番（GitHub Pages自動デプロイ）。直接コミットしない
+- `develop`: 開発ベース。PRはここ向け
+- `feature-<issue番号>-<キーワード>`: フィーチャーブランチ（git worktreeで作成）
+
+## case.json の概要
+
+6つの技術カテゴリ: synthetic_data, differential_privacy, anonymization, federated_learning, secure_computation, distributed_analytics
+
+主要フィールド: title, region, domain, organization, technology_category, usecase_category, occurred_at, summary, value_proposition, privacy_enhancement_method, safety_assurance_method, utility_evaluation_method, tags, sources, figures
+
+- スキーマ定義: `src/schemas/case.schema.ts`
+- 型定義: `src/types/case.ts`
+- カテゴリ定数: `src/constants/categories.ts`
+- プロンプトテンプレート: `src/constants/prompts.ts`
+
+## 事例の追加・レビューフロー
+
+1. 文献から事例を作成: `/case-create <URL>` または UIのAIアシストパネル
+2. 既存事例の補完: `/case-enrich <case-id> <URL>` または UIの編集画面
+3. レビュー: case-reviewer エージェントで品質チェック
+4. バリデーション: `npm run validate` でスキーマ検証
+
+## 注意事項
+
+- case.json の sources は最低1件必須
+- occurred_at は "YYYY" / "YYYY-MM" / "YYYY-MM-DD" / null（詳細不明）
+- 文献から読み取れない項目は「調査中」と記入（空欄にしない）
+- figures の data_flow ノードは source → constraint → process → application → outcome の流れ


### PR DESCRIPTION
## Summary
- プロジェクトレベルの CLAUDE.md を新規作成し、セッション開始時にプロジェクトコンテキストが自動提供されるように
- `/case-create` `/case-enrich` スキルで Claude Code 内からの事例作成・補完ワークフローを整備
- `case-reviewer` エージェントで事例の品質レビューを自律的に実行可能に

## Changes
- **`CLAUDE.md`**: プロジェクト概要、技術スタック、コマンド、ディレクトリ構成、ブランチ戦略、case.jsonフロー
- **`.claude/skills/case-create/SKILL.md`**: 文献URLからcase.json生成ワークフロー（prompts.ts参照、バリデーション、レビュー連携）
- **`.claude/skills/case-enrich/SKILL.md`**: 追加文献で既存事例を補完するワークフロー
- **`.claude/agents/case-reviewer.md`**: 3観点（事実確認・ビジネス・PETs技術）で自律レビュー。PASS/NEEDS_REVISION/FAIL判定

## Test plan
- [ ] 新セッションで CLAUDE.md が自動読み込みされることを確認
- [ ] `/case-create <URL>` でcase.json生成ワークフローが動作することを確認
- [ ] `/case-enrich <id> <URL>` で補完ワークフローが動作することを確認
- [ ] case-reviewer エージェントでレビューが実行できることを確認

Closes #76

🤖 Generated with [Claude Code](https://claude.com/claude-code)