### PR TITLE
fix: ページ遷移時にスクロール位置をトップにリセット

### DIFF
--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -1,8 +1,10 @@
 import { Outlet } from 'react-router-dom'
 import Header from './Header'
 import Footer from './Footer'
+import { useScrollToTop } from '../../hooks/useScrollToTop'
 
 export default function Layout() {
+  useScrollToTop()
   return (
     <div className="min-h-screen flex flex-col bg-gray-50 text-gray-900">
       <Header />

--- a/src/hooks/useScrollToTop.ts
+++ b/src/hooks/useScrollToTop.ts
@@ -1,0 +1,9 @@
+import { useEffect } from 'react'
+import { useLocation } from 'react-router-dom'
+
+export function useScrollToTop() {
+  const { pathname } = useLocation()
+  useEffect(() => {
+    window.scrollTo(0, 0)
+  }, [pathname])
+}


### PR DESCRIPTION
## Summary

- ページ遷移時にスクロール位置がリセットされず、詳細ページが途中から表示される問題を修正
- `useScrollToTop` カスタムフックを追加し、Layoutコンポーネントに組み込み

## 変更内容

- `src/hooks/useScrollToTop.ts`: 新規作成。`useLocation`の`pathname`変更を検知して`window.scrollTo(0, 0)`を実行
- `src/components/layout/Layout.tsx`: フックを追加（1行）

## Test plan

- [x] `npm run build` — ビルド成功
- [x] `npm run test` — 196テスト all passed
- [x] 一覧→詳細→一覧の遷移でスクロール位置がリセットされることを目視確認

Closes #90

🤖 Generated with [Claude Code](https://claude.com/claude-code)