### PR TITLE
fix: 課題・価値セクションの表現重複を解消 (#101)

### DIFF
--- a/src/__tests__/CaseDetailPage.test.tsx
+++ b/src/__tests__/CaseDetailPage.test.tsx
@@ -137,7 +137,7 @@ describe('CaseDetailPage', () => {
     expect(editLink.closest('a')).toHaveAttribute('href', '/cases/case-001/edit')
   })
 
-  it('data_flow図がある場合、constraintキーワードが「課題と解決」に表示される', () => {
+  it('data_flow図がある場合、constraint/outcomeキーワードが見出しに表示される', () => {
     const caseWithFigure: Case = {
       ...mockCase,
       figures: [{
@@ -158,14 +158,14 @@ describe('CaseDetailPage', () => {
     }
     mockedUseCases.mockReturnValue({ cases: [caseWithFigure], loading: false, error: null })
     renderWithRoute('case-001')
-    expect(screen.getByTestId('keyword-constraint')).toHaveTextContent('テスト制約')
-    expect(screen.getByTestId('keyword-outcome')).toHaveTextContent('テスト成果')
+    expect(screen.getByTestId('section-heading-constraint')).toHaveTextContent('課題：テスト制約')
+    expect(screen.getByTestId('section-heading-outcome')).toHaveTextContent('PETs適用により得られた価値：テスト成果')
   })
 
-  it('data_flow図がない場合、キーワードチップが表示されない', () => {
+  it('data_flow図がない場合、見出しはキーワード付きでない汎用表記になる', () => {
     renderWithRoute('case-001')
-    expect(screen.queryByTestId('keyword-constraint')).not.toBeInTheDocument()
-    expect(screen.queryByTestId('keyword-outcome')).not.toBeInTheDocument()
+    expect(screen.getByTestId('section-heading-constraint')).toHaveTextContent(/^課題$/)
+    expect(screen.getByTestId('section-heading-outcome')).toHaveTextContent(/^PETs適用により得られた価値$/)
   })
 
   it('review_statusバッジが表示される', () => {

--- a/src/components/case-detail/CaseDetailView.tsx
+++ b/src/components/case-detail/CaseDetailView.tsx
@@ -106,33 +106,19 @@ export default function CaseDetailView({ caseData }: { caseData: Case }) {
           <div className="p-5 space-y-5">
             {/* 課題 */}
             <section>
-              <h2 className="flex items-center gap-2 text-base font-bold mb-2">
+              <h2 className="flex items-center gap-2 text-base font-bold mb-2" data-testid="section-heading-constraint">
                 <span className="inline-block w-1 h-5 bg-slate-800 rounded-full" />
                 {keywords.constraint ? `課題：${keywords.constraint}` : '課題'}
               </h2>
-              {keywords.constraint && (
-                <p className="mb-1.5" data-testid="keyword-constraint">
-                  <span className="inline-flex items-center gap-1 text-xs font-medium bg-amber-50 border border-amber-200 text-amber-800 px-2.5 py-0.5 rounded">
-                    課題 | {keywords.constraint}
-                  </span>
-                </p>
-              )}
               <p className="text-sm text-gray-700 leading-relaxed">{caseData.summary}</p>
             </section>
 
             {/* PETs適用により得られた価値 */}
             <section>
-              <h2 className="flex items-center gap-2 text-base font-bold mb-2">
+              <h2 className="flex items-center gap-2 text-base font-bold mb-2" data-testid="section-heading-outcome">
                 <span className="inline-block w-1 h-5 bg-slate-800 rounded-full" />
                 {keywords.outcome ? `PETs適用により得られた価値：${keywords.outcome}` : 'PETs適用により得られた価値'}
               </h2>
-              {keywords.outcome && (
-                <p className="mb-1.5" data-testid="keyword-outcome">
-                  <span className="inline-flex items-center gap-1 text-xs font-medium bg-emerald-50 border border-emerald-200 text-emerald-800 px-2.5 py-0.5 rounded">
-                    成果 | {keywords.outcome}
-                  </span>
-                </p>
-              )}
               <p className="text-sm text-gray-700 leading-relaxed">{caseData.value_proposition}</p>
             </section>
 


### PR DESCRIPTION
## Summary
- 事例詳細ページで constraint/outcome のキーワードが見出しとバッジの2箇所に出ていた重複を解消
- 見出し `課題：{constraint}` / `PETs適用により得られた価値：{outcome}` への埋め込みのみを残し、直下のバッジ表示を削除

Closes #101

## Test plan
- [x] 単体テスト: CaseDetailPage で見出しに constraint/outcome が埋め込まれることを検証
- [x] data_flow 図がない場合に汎用見出しに戻ることを検証
- [x] `npm run test` 全件 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)