### PR TITLE
fix: Issue #107 レビュー棚卸し — auto-fix (sources.note 補完) 8件 (#107)

### DIFF
--- a/public/cases/16764965-168e-4d61-b5d6-29d3ac9adc92/case.json
+++ b/public/cases/16764965-168e-4d61-b5d6-29d3ac9adc92/case.json
@@ -32,13 +32,13 @@
       "source_type": "web",
       "title": "BWWC",
       "url": "https://thebwwc.org/mpc",
-      "note": ""
+      "note": "BWWC（ボストン女性労働力協議会）によるMPCを活用した給与格差分析プロジェクトの公式ページ"
     },
     {
       "source_type": "web",
       "title": "IEEE Conference Paper",
       "url": "https://ieeexplore.ieee.org/abstract/document/7839796",
-      "note": ""
+      "note": "Boston UniversityとBWWCによる、MPCを用いた男女賃金格差分析の学術論文（IEEE）"
     }
   ],
   "figures": [
@@ -81,5 +81,5 @@
   "occurred_at": "2021-07",
   "status": "seed",
   "created_at": "2026-03-21T07:12:31Z",
-  "updated_at": "2026-03-21T07:12:31Z"
+  "updated_at": "2026-04-17T00:00:00Z"
 }

--- a/public/cases/16a58f91-a50f-49f5-ba9e-f09968be5e67/case.json
+++ b/public/cases/16a58f91-a50f-49f5-ba9e-f09968be5e67/case.json
@@ -32,19 +32,19 @@
       "source_type": "web",
       "title": "Royal Society report on PETs",
       "url": "https://royalsociety.org/-/media/policy/projects/privacy-enhancing-technologies/privacy-enhancing-technologies-report.pdf",
-      "note": ""
+      "note": "Royal Society による PETs 報告書（差分プライバシーを含む概観）"
     },
     {
       "source_type": "web",
       "title": "Report on issues encountered implementing DP",
       "url": "https://arxiv.org/pdf/1809.02201.pdf",
-      "note": ""
+      "note": "米国国勢調査局における差分プライバシー実装の課題を論じた Garfinkel et al. (arXiv, 2018)"
     },
     {
       "source_type": "web",
       "title": "Explainer by the NCSL",
       "url": "https://www.ncsl.org/research/redistricting/differential-privacy-for-census-data-explained.aspx",
-      "note": ""
+      "note": "NCSL（全米州議会議員協議会）による2020年国勢調査における差分プライバシー適用の解説"
     }
   ],
   "figures": [
@@ -87,5 +87,5 @@
   "occurred_at": "2021-07",
   "status": "seed",
   "created_at": "2026-03-21T07:12:31Z",
-  "updated_at": "2026-03-21T07:12:31Z"
+  "updated_at": "2026-04-17T00:00:00Z"
 }

--- a/public/cases/19b2d243-022b-4451-b436-9239801204dc/case.json
+++ b/public/cases/19b2d243-022b-4451-b436-9239801204dc/case.json
@@ -35,13 +35,13 @@
       "source_type": "web",
       "title": "UN PETs Case Study repository",
       "url": "https://unstats.un.org/wiki/display/UGTTOPPT/11.+Statistics+Korea%3A+Developing+a+privacy-preserving+Statistical+Data+Hub+Platform",
-      "note": ""
+      "note": "UN統計委員会 PETs ケーススタディリポジトリ（韓国統計庁事例の紹介）"
     },
     {
       "source_type": "web",
       "title": "Kostat",
       "url": "https://kostat.go.kr/menu.es?mid=b10302010300",
-      "note": ""
+      "note": "韓国統計庁（KOSTAT）の公式Webサイト"
     }
   ],
   "figures": [
@@ -84,5 +84,5 @@
   "occurred_at": "2023-06",
   "status": "seed",
   "created_at": "2026-03-21T07:12:31Z",
-  "updated_at": "2026-03-21T07:12:31Z"
+  "updated_at": "2026-04-17T00:00:00Z"
 }

--- a/public/cases/21aae332-39b5-4d5f-b9ac-7a7d33a0361a/case.json
+++ b/public/cases/21aae332-39b5-4d5f-b9ac-7a7d33a0361a/case.json
@@ -35,13 +35,13 @@
       "source_type": "web",
       "title": "Youtube",
       "url": "https://www.youtube.com/watch?v=hvBb80eXuZg&feature=youtu.be",
-      "note": ""
+      "note": "TNO による MPC を用いた心不全リスク予測プロジェクトの解説動画（YouTube）"
     },
     {
       "source_type": "web",
       "title": "Medium blog",
       "url": "https://medium.com/applied-mpc/identifying-heart-failure-patients-at-high-risk-using-mpc-ab8900e75295",
-      "note": ""
+      "note": "Applied MPC による TNO・Erasmus MC・Zilveren Kruis 連携事例の解説記事（Medium）"
     }
   ],
   "figures": [
@@ -84,5 +84,5 @@
   "occurred_at": "2021-07",
   "status": "seed",
   "created_at": "2026-03-21T07:12:31Z",
-  "updated_at": "2026-03-21T07:12:31Z"
+  "updated_at": "2026-04-17T00:00:00Z"
 }

--- a/public/cases/af0b38e6-42e7-49d2-a9d0-625ce663bf7b/case.json
+++ b/public/cases/af0b38e6-42e7-49d2-a9d0-625ce663bf7b/case.json
@@ -32,7 +32,7 @@
       "source_type": "web",
       "title": "Statice case study",
       "url": "https://www.statice.ai/case-study/provinzial-predictive-analytics-synthetic-insurance-data#get-case-study",
-      "note": ""
+      "note": "Statice による Provinzial 向け合成データ活用のベンダー事例紹介ページ（フォーム経由で全文PDF）"
     }
   ],
   "figures": [
@@ -75,5 +75,5 @@
   "occurred_at": "2023-06",
   "status": "seed",
   "created_at": "2026-03-21T07:12:31Z",
-  "updated_at": "2026-03-21T07:12:31Z"
+  "updated_at": "2026-04-17T00:00:00Z"
 }

--- a/public/cases/anon-0014/case.json
+++ b/public/cases/anon-0014/case.json
@@ -26,7 +26,8 @@
     {
       "source_type": "web",
       "title": "匿名加工情報の作成及び第三者への提供について",
-      "url": "https://www.niigata-kouiki.jp/news/001306.html"
+      "url": "https://www.niigata-kouiki.jp/news/001306.html",
+      "note": "新潟県後期高齢者医療広域連合 公式ニュースリリース（個人非特定データを用いたデータヘルス計画の費用対効果分析）"
     }
   ],
   "figures": [
@@ -69,5 +70,5 @@
   "status": "seed",
   "occurred_at": null,
   "created_at": "2026-03-08T00:00:00+09:00",
-  "updated_at": "2026-03-08T00:00:00+09:00"
+  "updated_at": "2026-04-17T00:00:00Z"
 }

--- a/public/cases/dp-0013/case.json
+++ b/public/cases/dp-0013/case.json
@@ -25,7 +25,8 @@
     {
       "source_type": "web",
       "title": "AWS Clean Rooms Differential Privacy",
-      "url": "https://aws.amazon.com/blogs/aws/aws-clean-rooms-differential-privacy-enhances-privacy-protection-of-your-users-data-preview/"
+      "url": "https://aws.amazon.com/blogs/aws/aws-clean-rooms-differential-privacy-enhances-privacy-protection-of-your-users-data-preview/",
+      "note": "AWS 公式ブログ：Clean Rooms Differential Privacy 機能の発表記事"
     }
   ],
   "figures": [
@@ -71,5 +72,5 @@
   "status": "seed",
   "occurred_at": null,
   "created_at": "2026-03-08T00:00:00+09:00",
-  "updated_at": "2026-03-08T00:00:00+09:00"
+  "updated_at": "2026-04-17T00:00:00Z"
 }

--- a/public/cases/fl-0003/case.json
+++ b/public/cases/fl-0003/case.json
@@ -28,7 +28,8 @@
     {
       "source_type": "web",
       "title": "プライバシー保護連合学習技術「DeepProtect」「eFL-Boost」を活用した不正送金検知の実証実験を実施",
-      "url": "https://www.nict.go.jp/press/2025/07/22-1.html"
+      "url": "https://www.nict.go.jp/press/2025/07/22-1.html",
+      "note": "NICT プレスリリース：DeepProtect・eFL-Boost による3銀行参加の不正送金検知実証実験（2025年7月22日）"
     }
   ],
   "figures": [
@@ -71,5 +72,5 @@
   "status": "seed",
   "occurred_at": "2025",
   "created_at": "2025-07-22T00:00:00+09:00",
-  "updated_at": "2026-03-07T00:00:00+09:00"
+  "updated_at": "2026-04-17T00:00:00Z"
 }


### PR DESCRIPTION
## Summary

Issue #107（全ai_generated事例の5観点レビュー＆棚卸し）の Phase 3-1 成果物です。
16サブエージェント×4波の並列レビューで `auto_fix_safe` と分類された8件について、conservative な自動修正（`sources[].note` 空欄の補完）を適用しました。

## 対象 case（8件）

| case_id | 補完した note 数 |
|---|---|
| 16764965 (BWWC ジェンダー賃金格差) | 2件 |
| 16a58f91 (米国国勢調査 2020年DP) | 3件 |
| 19b2d243 (韓国統計庁 PETsハブ) | 2件 |
| 21aae332 (オランダTNO 心不全予測) | 2件 |
| af0b38e6 (Provinzial 合成データ) | 1件 |
| anon-0014 (新潟県後期高齢者広域連合) | 1件 |
| dp-0013 (AWS Clean Rooms DP) | 1件 |
| fl-0003 (NICT 3銀行不正送金検知) | 1件 |

合計 13件の `sources[].note` を補完。

## 適用した修正の範囲

- **対象**: `sources[].note` の空欄のみ（レビューで確認できた範囲で補完）
- **updated_at** を `2026-04-17T00:00:00Z` に更新
- **review_status は変更していない**（軽微修正に留める）

レビュー結果で auto_fix_safe と分類された case の中にも、`usecase_category` や `technology_category` の見直しなど人判断を要する論点が含まれていたため、それらは個別Issue（#107 の Phase 3-2 成果物、別途連番）で追跡対象としました。

## 検証結果

- `npx tsx scripts/validate-cases.ts` → All 139 cases valid
- `npm run build` → 成功（163 modules transformed, 644ms）

## 参照

- 親Issue: #107
- Phase 3-2 で作成した個別Issue: #112–#214（review_status の確定作業を各 case 単位で追跡）

## Test plan

- [x] `npm run validate` でスキーマ違反がないことを確認
- [x] `npm run build` で TypeScript エラーがないことを確認
- [ ] 差分のJSON構造が壊れていないことをレビュアーが目視確認

Closes #107

🤖 Generated with [Claude Code](https://claude.com/claude-code)