### PR TITLE
refactor: Plugin を tooling/ へ移設＋純粋ロジック抽出 (Phase 3/4, #110)

### DIFF
--- a/tests/unit/tooling/generate-case-index.test.ts
+++ b/tests/unit/tooling/generate-case-index.test.ts
@@ -1,28 +1,10 @@
-import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
-import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, existsSync, rmSync } from 'node:fs'
-import { join } from 'node:path'
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { mkdtempSync, mkdirSync, writeFileSync, existsSync, rmSync, readdirSync } from 'node:fs'
+import { join, resolve } from 'node:path'
 import { tmpdir } from 'node:os'
+import { listCaseIds, buildIndexContent } from '../../../tooling/lib/case-index'
 
-// generate() のロジックを直接テストするためにヘルパーを抽出
-// プラグインは resolve('public/cases') を使うため、
-// ここではプラグインの generate ロジックを再現してテスト
-
-function generateIndex(casesDir: string): { cases: string[] } | null {
-  if (!existsSync(casesDir)) return null
-
-  const { readdirSync } = require('node:fs')
-  const ids = readdirSync(casesDir, { withFileTypes: true })
-    .filter(
-      (d: { isDirectory: () => boolean; name: string }) =>
-        d.isDirectory() && existsSync(join(casesDir, d.name, 'case.json'))
-    )
-    .map((d: { name: string }) => d.name)
-    .sort()
-
-  return { cases: ids }
-}
-
-describe('generate-case-index ロジック', () => {
+describe('listCaseIds', () => {
   let tempDir: string
 
   beforeEach(() => {
@@ -34,20 +16,14 @@ describe('generate-case-index ロジック', () => {
   })
 
   it('case.json を持つディレクトリのみをリストアップする', () => {
-    // case.json あり
     mkdirSync(join(tempDir, 'seed-0001'))
     writeFileSync(join(tempDir, 'seed-0001', 'case.json'), '{}')
     mkdirSync(join(tempDir, 'rpt-0001'))
     writeFileSync(join(tempDir, 'rpt-0001', 'case.json'), '{}')
-
-    // case.json なし（無視されるべき）
     mkdirSync(join(tempDir, 'empty-dir'))
-
-    // ファイル（ディレクトリではない）
     writeFileSync(join(tempDir, 'not-a-dir.txt'), '')
 
-    const result = generateIndex(tempDir)
-    expect(result).toEqual({ cases: ['rpt-0001', 'seed-0001'] })
+    expect(listCaseIds(tempDir)).toEqual(['rpt-0001', 'seed-0001'])
   })
 
   it('ディレクトリがソートされて返される', () => {
@@ -56,42 +32,43 @@ describe('generate-case-index ロジック', () => {
       writeFileSync(join(tempDir, id, 'case.json'), '{}')
     }
 
-    const result = generateIndex(tempDir)
-    expect(result?.cases).toEqual(['fpf-0002', 'rpt-0010', 'seed-0001', 'seed-0003'])
+    expect(listCaseIds(tempDir)).toEqual(['fpf-0002', 'rpt-0010', 'seed-0001', 'seed-0003'])
   })
 
   it('空のディレクトリでは空配列を返す', () => {
-    const result = generateIndex(tempDir)
-    expect(result).toEqual({ cases: [] })
+    expect(listCaseIds(tempDir)).toEqual([])
   })
 
-  it('存在しないディレクトリではnullを返す', () => {
-    const result = generateIndex(join(tempDir, 'nonexistent'))
-    expect(result).toBeNull()
+  it('存在しないディレクトリでは null を返す', () => {
+    expect(listCaseIds(join(tempDir, 'nonexistent'))).toBeNull()
   })
 
-  it('全事例がindex.jsonに含まれることを検証（回帰テスト）', () => {
-    // 実際の public/cases/ を読み取って、index生成ロジックと一致するか確認
-    const { resolve } = require('node:path')
+  it('全事例が含まれることを検証（回帰テスト）', () => {
     const realCasesDir = resolve(__dirname, '../../../public/cases')
-    if (!existsSync(realCasesDir)) return // CI等で存在しない場合はスキップ
+    if (!existsSync(realCasesDir)) return
 
-    const result = generateIndex(realCasesDir)
-    expect(result).not.toBeNull()
+    const ids = listCaseIds(realCasesDir)
+    expect(ids).not.toBeNull()
 
-    // 各ディレクトリに対応するcase.jsonが存在することを確認
-    for (const id of result!.cases) {
-      const casePath = join(realCasesDir, id, 'case.json')
-      expect(existsSync(casePath)).toBe(true)
+    for (const id of ids!) {
+      expect(existsSync(join(realCasesDir, id, 'case.json'))).toBe(true)
     }
 
-    // ディレクトリ数と一致することを確認（漏れがないか）
-    const { readdirSync } = require('node:fs')
-    const allDirs = readdirSync(realCasesDir, { withFileTypes: true })
-      .filter(
-        (d: { isDirectory: () => boolean; name: string }) =>
-          d.isDirectory() && existsSync(join(realCasesDir, d.name, 'case.json'))
-      )
-    expect(result!.cases.length).toBe(allDirs.length)
+    const allDirs = readdirSync(realCasesDir, { withFileTypes: true }).filter(
+      (d) => d.isDirectory() && existsSync(join(realCasesDir, d.name, 'case.json'))
+    )
+    expect(ids!.length).toBe(allDirs.length)
+  })
+})
+
+describe('buildIndexContent', () => {
+  it('ids を JSON 文字列にし末尾改行を付ける', () => {
+    const out = buildIndexContent(['a', 'b', 'c'])
+    expect(out).toBe(JSON.stringify({ cases: ['a', 'b', 'c'] }, null, 2) + '\n')
+    expect(out.endsWith('\n')).toBe(true)
+  })
+
+  it('空配列でも JSON を出力', () => {
+    expect(buildIndexContent([])).toBe('{\n  "cases": []\n}\n')
   })
 })

--- a/tooling/lib/case-index.ts
+++ b/tooling/lib/case-index.ts
@@ -1,0 +1,15 @@
+import { readdirSync, existsSync } from 'node:fs'
+import { join } from 'node:path'
+
+export function listCaseIds(casesDir: string): string[] | null {
+  if (!existsSync(casesDir)) return null
+
+  return readdirSync(casesDir, { withFileTypes: true })
+    .filter((d) => d.isDirectory() && existsSync(join(casesDir, d.name, 'case.json')))
+    .map((d) => d.name)
+    .sort()
+}
+
+export function buildIndexContent(ids: string[]): string {
+  return JSON.stringify({ cases: ids }, null, 2) + '\n'
+}

--- a/tooling/vite-plugins/generate-case-index.ts
+++ b/tooling/vite-plugins/generate-case-index.ts
@@ -1,28 +1,18 @@
-import { readdirSync, existsSync, writeFileSync, readFileSync } from 'node:fs'
+import { existsSync, writeFileSync, readFileSync } from 'node:fs'
 import { resolve, join } from 'node:path'
 import type { Plugin } from 'vite'
+import { listCaseIds, buildIndexContent } from '../lib/case-index'
 
-/**
- * public/cases/ 配下のフォルダを走査し、
- * case.json を持つフォルダのIDを index.json に書き出す Vite プラグイン。
- *
- * dev サーバー起動時・ビルド時に自動実行されるため、手動で index.json を更新する必要がなくなる。
- */
 export default function generateCaseIndex(): Plugin {
   const casesDir = resolve('public/cases')
 
   function generate() {
-    if (!existsSync(casesDir)) return
-
-    const ids = readdirSync(casesDir, { withFileTypes: true })
-      .filter((d) => d.isDirectory() && existsSync(join(casesDir, d.name, 'case.json')))
-      .map((d) => d.name)
-      .sort()
+    const ids = listCaseIds(casesDir)
+    if (ids === null) return
 
     const indexPath = join(casesDir, 'index.json')
-    const newContent = JSON.stringify({ cases: ids }, null, 2) + '\n'
+    const newContent = buildIndexContent(ids)
 
-    // 変更がある場合のみ書き込み（不要なHMRトリガーを防止）
     const current = existsSync(indexPath) ? readFileSync(indexPath, 'utf-8') : ''
     if (current !== newContent) {
       writeFileSync(indexPath, newContent)
@@ -36,7 +26,6 @@ export default function generateCaseIndex(): Plugin {
       generate()
     },
     configureServer(server) {
-      // public/cases/ 配下のフォルダ追加・削除を監視
       server.watcher.on('addDir', (path) => {
         if (path.startsWith(casesDir)) generate()
       })

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from 'vitest/config'
 import react from '@vitejs/plugin-react'
 import tailwindcss from '@tailwindcss/vite'
-import generateCaseIndex from './plugins/generate-case-index'
+import generateCaseIndex from './tooling/vite-plugins/generate-case-index'
 
 export default defineConfig({
   plugins: [react(), tailwindcss(), generateCaseIndex()],


### PR DESCRIPTION
Closes #110 (Phase 3/4 of #102)

## Summary
- `plugins/generate-case-index.ts` → `tooling/vite-plugins/generate-case-index.ts` に移設
- 走査/シリアライズの純粋ロジックを `tooling/lib/case-index.ts` に抽出（`listCaseIds`, `buildIndexContent`）
- plugin 側には I/O（`writeFileSync`, watcher）のみ残す
- テスト（`tests/unit/tooling/generate-case-index.test.ts`）が `require` でロジックを再実装していたのをやめ、`tooling/lib/case-index.ts` を直接テスト
- `vite.config.ts` の import パスを更新
- `plugins/` ディレクトリ削除

## Test plan
- [x] `npx tsc -b --noEmit` 通過
- [x] `npm run test` 25 files / 204 tests 全通過（+2 件: `buildIndexContent`）
- [x] `npm run build` 成功（`public/cases/index.json` が 139 件で生成）
- [x] `npm run dev` watcher 動作確認: ダミー `public/cases/test-dummy-xyz/case.json` 追加→`Updated index.json (140 cases)`、削除→`Updated index.json (139 cases)`
- [x] `plugins/` が存在しないことを確認

## 注意事項
- base は `feature-102-dir-refactor`（Phase 1〜2 が取り込まれているステージングブランチ）
- 次は Phase 4 (#111) で `scripts/` を `ops/oneoff` に二分する

🤖 Generated with [Claude Code](https://claude.com/claude-code)