### PR TITLE
UX: 詳細ページの見出し「価値」に短縮 (#225)

### DIFF
--- a/src/__tests__/CaseDetailPage.test.tsx
+++ b/src/__tests__/CaseDetailPage.test.tsx
@@ -70,9 +70,9 @@ describe('CaseDetailPage', () => {
     expect(screen.getByText('テスト概要の内容です')).toBeInTheDocument()
   })
 
-  it('左カラムにvalue_propositionが「PETs適用により得られた価値」として表示される', () => {
+  it('左カラムにvalue_propositionが「価値」として表示される', () => {
     renderWithRoute('case-001')
-    expect(screen.getByText('PETs適用により得られた価値')).toBeInTheDocument()
+    expect(screen.getByTestId('section-heading-outcome')).toHaveTextContent(/^価値$/)
     expect(screen.getByText('テスト成果の内容です')).toBeInTheDocument()
   })
 
@@ -159,13 +159,13 @@ describe('CaseDetailPage', () => {
     mockedUseCases.mockReturnValue({ cases: [caseWithFigure], loading: false, error: null })
     renderWithRoute('case-001')
     expect(screen.getByTestId('section-heading-constraint')).toHaveTextContent('課題：テスト制約')
-    expect(screen.getByTestId('section-heading-outcome')).toHaveTextContent('PETs適用により得られた価値：テスト成果')
+    expect(screen.getByTestId('section-heading-outcome')).toHaveTextContent('価値：テスト成果')
   })
 
   it('data_flow図がない場合、見出しはキーワード付きでない汎用表記になる', () => {
     renderWithRoute('case-001')
     expect(screen.getByTestId('section-heading-constraint')).toHaveTextContent(/^課題$/)
-    expect(screen.getByTestId('section-heading-outcome')).toHaveTextContent(/^PETs適用により得られた価値$/)
+    expect(screen.getByTestId('section-heading-outcome')).toHaveTextContent(/^価値$/)
   })
 
   it('review_statusバッジが表示される', () => {

--- a/src/components/case-detail/CaseDetailView.tsx
+++ b/src/components/case-detail/CaseDetailView.tsx
@@ -113,11 +113,11 @@ export default function CaseDetailView({ caseData }: { caseData: Case }) {
               <p className="text-sm text-gray-700 leading-relaxed">{caseData.summary}</p>
             </section>
 
-            {/* PETs適用により得られた価値 */}
+            {/* 価値 */}
             <section>
               <h2 className="flex items-center gap-2 text-base font-bold mb-2" data-testid="section-heading-outcome">
                 <span className="inline-block w-1 h-5 bg-slate-800 rounded-full" />
-                {keywords.outcome ? `PETs適用により得られた価値：${keywords.outcome}` : 'PETs適用により得られた価値'}
+                {keywords.outcome ? `価値：${keywords.outcome}` : '価値'}
               </h2>
               <p className="text-sm text-gray-700 leading-relaxed">{caseData.value_proposition}</p>
             </section>


### PR DESCRIPTION
## Summary
- 事例詳細ページの value_proposition セクション見出しを「PETs適用により得られた価値」→「価値」に短縮
- キーワード付き表示（`PETs適用により得られた価値：xxx`）も「価値：xxx」に変更
- 対応するテストを testId ベースのアサーションに更新

## 変更ファイル
- \`src/components/case-detail/CaseDetailView.tsx\` L116,120
- \`src/__tests__/CaseDetailPage.test.tsx\` L73,75,162,168

## スコープ外（Issue 記載どおり据え置き）
- \`src/components/case-form/BasicFields.tsx\` のフォームラベル
- \`src/constants/prompts.ts\` の AI 生成指示文言

## Test plan
- [x] \`npm run test\` 全202件 pass
- [ ] dev サーバで見出しが「価値」に短縮されていることを目視確認（keywords.outcome あり/なし両方）

Closes #225

🤖 Generated with [Claude Code](https://claude.com/claude-code)