### PR TITLE
feat: case編集フォームに figures セクションを追加 (#223)

### DIFF
--- a/src/__tests__/CaseForm.test.tsx
+++ b/src/__tests__/CaseForm.test.tsx
@@ -120,4 +120,125 @@ describe('CaseForm', () => {
     expect(submitted.created_at).toBe('2026-01-01T00:00:00Z')
     expect(submitted.status).toBe('user')
   })
+
+  describe('図表セクション', () => {
+    it('図表セクションはデフォルトで折りたたまれている', () => {
+      render(<CaseForm onSubmit={() => {}} submitLabel="作成" />)
+      expect(screen.getByText('図表')).toBeInTheDocument()
+      expect(screen.queryByText('+ data_flow 図を追加')).not.toBeInTheDocument()
+    })
+
+    it('図表セクションを展開すると追加ボタンが表示される', async () => {
+      const user = userEvent.setup()
+      render(<CaseForm onSubmit={() => {}} submitLabel="作成" />)
+
+      await user.click(screen.getByText('図表'))
+      expect(screen.getByText('+ data_flow 図を追加')).toBeInTheDocument()
+    })
+
+    it('data_flow を追加しノードを登録すると submit 時に figures に反映される', async () => {
+      const user = userEvent.setup()
+      const onSubmit = vi.fn()
+      render(<CaseForm onSubmit={onSubmit} submitLabel="作成" />)
+
+      // 出典URL（必須）
+      await user.type(screen.getByPlaceholderText('https://...'), 'https://example.com')
+
+      // 図表セクションを開いて data_flow を追加
+      await user.click(screen.getByText('図表'))
+      await user.click(screen.getByText('+ data_flow 図を追加'))
+
+      // タイトル入力
+      await user.type(document.getElementById('figures.0.title') as HTMLInputElement, 'テストフロー')
+
+      // ノード追加（source → constraint → process → application → outcome）
+      await user.click(screen.getByRole('button', { name: '+ source' }))
+      await user.click(screen.getByRole('button', { name: '+ process' }))
+      await user.click(screen.getByRole('button', { name: '+ outcome' }))
+
+      const labelInputs = screen.getAllByPlaceholderText('例: 医療データを匿名化処理')
+      await user.type(labelInputs[0], '元データ')
+      await user.type(labelInputs[1], '合成データ生成')
+      await user.type(labelInputs[2], '有用性97%達成')
+
+      await user.click(screen.getByRole('button', { name: '作成' }))
+
+      await waitFor(() => {
+        expect(onSubmit).toHaveBeenCalledTimes(1)
+      })
+
+      const submitted = onSubmit.mock.calls[0][0] as Case
+      expect(submitted.figures).toHaveLength(1)
+      expect(submitted.figures[0].type).toBe('data_flow')
+      expect(submitted.figures[0].title).toBe('テストフロー')
+      const data = submitted.figures[0].data as { nodes: Array<{ id: string; label: string; category: string }> }
+      expect(data.nodes).toEqual([
+        { id: 's1', label: '元データ', category: 'source' },
+        { id: 'p1', label: '合成データ生成', category: 'process' },
+        { id: 'a1', label: '有用性97%達成', category: 'outcome' },
+      ])
+    })
+
+    it('既存の figures（edges含む）が編集後も保持される', async () => {
+      const user = userEvent.setup()
+      const onSubmit = vi.fn()
+      const caseWithFigure: Case = {
+        ...mockCase,
+        figures: [{
+          type: 'data_flow',
+          title: '既存フロー',
+          data: {
+            nodes: [{ id: 's1', label: '既存元データ', category: 'source' }],
+            edges: [{ from: 's1', to: 'p1', label: '供給' }],
+          },
+          note: '既存メモ',
+        }],
+      }
+      render(<CaseForm defaultValues={caseWithFigure} onSubmit={onSubmit} submitLabel="更新" />)
+
+      await user.click(screen.getByRole('button', { name: '更新' }))
+
+      await waitFor(() => {
+        expect(onSubmit).toHaveBeenCalledTimes(1)
+      })
+
+      const submitted = onSubmit.mock.calls[0][0] as Case
+      expect(submitted.figures).toHaveLength(1)
+      expect(submitted.figures[0].title).toBe('既存フロー')
+      const data = submitted.figures[0].data as {
+        nodes: Array<{ id: string; label: string; category: string }>
+        edges: Array<{ from: string; to: string; label: string }>
+      }
+      expect(data.nodes).toEqual([{ id: 's1', label: '既存元データ', category: 'source' }])
+      expect(data.edges).toEqual([{ from: 's1', to: 'p1', label: '供給' }])
+    })
+
+    it('ラベル空のノードは submit 時に除外される', async () => {
+      const user = userEvent.setup()
+      const onSubmit = vi.fn()
+      render(<CaseForm onSubmit={onSubmit} submitLabel="作成" />)
+
+      await user.type(screen.getByPlaceholderText('https://...'), 'https://example.com')
+      await user.click(screen.getByText('図表'))
+      await user.click(screen.getByText('+ data_flow 図を追加'))
+      await user.type(document.getElementById('figures.0.title') as HTMLInputElement, 'テスト')
+
+      // 2ノード追加、1つだけラベル入力
+      await user.click(screen.getByRole('button', { name: '+ source' }))
+      await user.click(screen.getByRole('button', { name: '+ process' }))
+      const labelInputs = screen.getAllByPlaceholderText('例: 医療データを匿名化処理')
+      await user.type(labelInputs[0], '元データ')
+      // 2つ目は空のまま
+
+      await user.click(screen.getByRole('button', { name: '作成' }))
+
+      await waitFor(() => {
+        expect(onSubmit).toHaveBeenCalledTimes(1)
+      })
+
+      const submitted = onSubmit.mock.calls[0][0] as Case
+      const data = submitted.figures[0].data as { nodes: unknown[] }
+      expect(data.nodes).toHaveLength(1)
+    })
+  })
 })

--- a/src/__tests__/prompts.test.ts
+++ b/src/__tests__/prompts.test.ts
@@ -65,6 +65,10 @@ describe('generateCreatePrompt', () => {
   it('不明項目は「調査中」とする指示を含む', () => {
     expect(prompt).toContain('調査中')
   })
+
+  it('data_flow のカテゴリ順序ルールを含む', () => {
+    expect(prompt).toContain('source → constraint → process → application → outcome')
+  })
 })
 
 describe('generateEnrichPrompt', () => {
@@ -109,5 +113,10 @@ describe('generateEnrichPrompt', () => {
   it('occurred_at の補完ルールを含む', () => {
     const prompt = generateEnrichPrompt('{}')
     expect(prompt).toContain('occurred_at')
+  })
+
+  it('data_flow のカテゴリ順序ルールを含む', () => {
+    const prompt = generateEnrichPrompt('{}')
+    expect(prompt).toContain('source → constraint → process → application → outcome')
   })
 })

--- a/src/components/case-form/CaseForm.tsx
+++ b/src/components/case-form/CaseForm.tsx
@@ -11,6 +11,7 @@ import TagInput from './TagInput'
 import CategoryCheckboxes from './CategoryCheckboxes'
 import AiAssistPanel from './AiAssistPanel'
 import ReviewStatusField from './ReviewStatusField'
+import FiguresField, { normalizeFigures } from './FiguresField'
 
 function CollapsibleSection({ title, badge, children }: { title: string; badge?: string; children: React.ReactNode }) {
   const [open, setOpen] = useState(false)
@@ -58,6 +59,22 @@ export default function CaseForm({ defaultValues, onSubmit, submitLabel }: CaseF
       occurred_at: defaultValues?.occurred_at ?? '',
       tags: defaultValues?.tags ?? [],
       sources: defaultValues?.sources ?? [{ source_type: 'web', title: '', url: '', note: '' }],
+      figures: (defaultValues?.figures ?? []).map((f) => ({
+        type: f.type,
+        title: f.title ?? '',
+        // data_flow のみフォームで編集。非 data_flow は undefined にし、submit時に原データを復元
+        data: f.type === 'data_flow'
+          ? {
+              nodes: (f.data as { nodes?: Array<{ id?: string; label?: string; category?: string }> }).nodes?.map((n) => ({
+                id: n.id ?? '',
+                label: n.label ?? '',
+                category: n.category ?? '',
+              })) ?? [],
+              edges: (f.data as { edges?: Array<{ from: string; to: string; label: string }> }).edges ?? [],
+            }
+          : undefined,
+        note: f.note ?? '',
+      })),
     },
   })
 
@@ -74,13 +91,14 @@ export default function CaseForm({ defaultValues, onSubmit, submitLabel }: CaseF
 
   function handleSubmit(formData: CaseFormData) {
     const now = new Date().toISOString()
+    const normalizedFigures = normalizeFigures(formData.figures, defaultValues?.figures)
     const fullCase: Case = {
       ...formData,
       id: isEdit ? defaultValues!.id! : crypto.randomUUID(),
       technology_category: formData.technology_category ?? ['synthetic_data'],
       review_status: formData.review_status ?? 'ai_generated',
       occurred_at: formData.occurred_at || null,
-      figures: defaultValues?.figures ?? [],
+      figures: normalizedFigures as Case['figures'],
       status: isEdit ? defaultValues!.status! : 'user',
       created_at: isEdit ? defaultValues!.created_at! : now,
       updated_at: now,
@@ -182,6 +200,11 @@ export default function CaseForm({ defaultValues, onSubmit, submitLabel }: CaseF
         {/* 折りたたみ: タグ */}
         <CollapsibleSection title="タグ" badge="任意">
           <TagInput />
+        </CollapsibleSection>
+
+        {/* 折りたたみ: 図表 */}
+        <CollapsibleSection title="図表" badge="任意">
+          <FiguresField />
         </CollapsibleSection>
 
         <div>

--- a/src/components/case-form/FiguresField.tsx
+++ b/src/components/case-form/FiguresField.tsx
@@ -1,0 +1,259 @@
+import { useFormContext, useFieldArray, useWatch } from 'react-hook-form'
+import type { CaseFormData } from '../../schemas/case.schema'
+import {
+  DATA_FLOW_NODE_CATEGORIES,
+  DATA_FLOW_NODE_CATEGORY_LABELS,
+  DATA_FLOW_NODE_ID_PREFIX,
+  type DataFlowNodeCategory,
+} from '../../constants/categories'
+
+export default function FiguresField() {
+  const { control } = useFormContext<CaseFormData>()
+  const { fields, append, remove } = useFieldArray({ control, name: 'figures' })
+
+  return (
+    <div className="space-y-4">
+      {fields.length === 0 && (
+        <p className="text-sm text-gray-500">
+          図表は任意です。data_flow 図を追加するとフロー図が詳細ページに表示されます。
+        </p>
+      )}
+
+      {fields.map((field, index) => (
+        <FigureCard key={field.id} index={index} onRemove={() => remove(index)} />
+      ))}
+
+      <button
+        type="button"
+        onClick={() =>
+          append({
+            type: 'data_flow',
+            title: '',
+            data: { nodes: [], edges: [] },
+            note: '',
+          })
+        }
+        className="rounded bg-gray-100 px-4 py-2 text-sm hover:bg-gray-200"
+      >
+        + data_flow 図を追加
+      </button>
+    </div>
+  )
+}
+
+function FigureCard({ index, onRemove }: { index: number; onRemove: () => void }) {
+  const { register, control } = useFormContext<CaseFormData>()
+  const type = useWatch({ control, name: `figures.${index}.type` })
+
+  return (
+    <div className="rounded-lg border border-gray-200 p-4 space-y-3 bg-white">
+      <div className="flex items-center justify-between">
+        <span className="text-sm font-medium">
+          図表 {index + 1}
+          <span className="ml-2 text-xs text-gray-500">（type: {type ?? 'data_flow'}）</span>
+        </span>
+        <button type="button" onClick={onRemove} className="text-sm text-red-600 hover:underline">
+          削除
+        </button>
+      </div>
+
+      <div>
+        <label htmlFor={`figures.${index}.title`} className="block text-sm font-medium">タイトル</label>
+        <input
+          id={`figures.${index}.title`}
+          type="text"
+          {...register(`figures.${index}.title`)}
+          placeholder="例: {事例名}のPETs活用フロー"
+          className="mt-1 block w-full rounded border border-gray-300 px-3 py-2"
+        />
+      </div>
+
+      {type === 'data_flow' ? (
+        <DataFlowNodesField figureIndex={index} />
+      ) : (
+        <p className="text-xs text-gray-500 bg-gray-50 rounded px-3 py-2">
+          この図タイプ（{type}）のフォーム編集には現時点で未対応です。値は保持されます。詳細な編集が必要な場合は JSON で直接編集してください。
+        </p>
+      )}
+
+      <div>
+        <label htmlFor={`figures.${index}.note`} className="block text-sm font-medium">補足メモ</label>
+        <input
+          id={`figures.${index}.note`}
+          type="text"
+          {...register(`figures.${index}.note`)}
+          className="mt-1 block w-full rounded border border-gray-300 px-3 py-2"
+        />
+      </div>
+    </div>
+  )
+}
+
+function DataFlowNodesField({ figureIndex }: { figureIndex: number }) {
+  const { control, register } = useFormContext<CaseFormData>()
+  const { fields, append, remove } = useFieldArray({
+    control,
+    name: `figures.${figureIndex}.data.nodes` as const,
+  })
+
+  return (
+    <div className="space-y-2">
+      <div className="flex items-center justify-between">
+        <span className="block text-sm font-medium">ノード</span>
+        <span className="text-xs text-gray-500">
+          順序: source → constraint → process → application → outcome
+        </span>
+      </div>
+
+      {fields.map((field, i) => (
+        <div key={field.id} className="rounded border border-gray-200 p-3 space-y-2 bg-gray-50">
+          <div className="flex items-center justify-between">
+            <span className="text-xs text-gray-600">ノード {i + 1}</span>
+            <button type="button" onClick={() => remove(i)} className="text-xs text-red-600 hover:underline">
+              削除
+            </button>
+          </div>
+          <div className="grid grid-cols-1 md:grid-cols-[1fr_200px] gap-2">
+            <div>
+              <label className="block text-xs text-gray-600">ラベル</label>
+              <input
+                type="text"
+                {...register(`figures.${figureIndex}.data.nodes.${i}.label`)}
+                placeholder="例: 医療データを匿名化処理"
+                className="mt-1 block w-full rounded border border-gray-300 px-2 py-1 text-sm"
+              />
+            </div>
+            <div>
+              <label className="block text-xs text-gray-600">分類</label>
+              <select
+                {...register(`figures.${figureIndex}.data.nodes.${i}.category`)}
+                className="mt-1 block w-full rounded border border-gray-300 px-2 py-1 text-sm"
+              >
+                <option value="">未選択</option>
+                {DATA_FLOW_NODE_CATEGORIES.map((cat) => (
+                  <option key={cat} value={cat}>
+                    {DATA_FLOW_NODE_CATEGORY_LABELS[cat]}
+                  </option>
+                ))}
+              </select>
+            </div>
+          </div>
+          {/* id は非表示。submit 時にカテゴリから自動採番する */}
+          <input type="hidden" {...register(`figures.${figureIndex}.data.nodes.${i}.id`)} />
+        </div>
+      ))}
+
+      <div className="flex flex-wrap gap-2">
+        {DATA_FLOW_NODE_CATEGORIES.map((cat) => (
+          <button
+            key={cat}
+            type="button"
+            onClick={() =>
+              append({
+                id: '',
+                label: '',
+                category: cat,
+              })
+            }
+            className="rounded bg-white border border-gray-300 px-2 py-1 text-xs hover:bg-gray-100"
+          >
+            + {cat}
+          </button>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+/**
+ * Form の緩い figures 値を Case 型に適合する形に正規化する。
+ * - data_flow 図: ラベル空ノード除外、空ID をカテゴリに応じて自動採番（s1/p1/a1 形式）
+ * - data_flow 図でタイトルも空・ノード0件 → figure 全体を除外
+ * - 非 data_flow 図（risk_matrix / utility_chart）: defaultValues から透過保持
+ */
+export function normalizeFigures(
+  formFigures: CaseFormData['figures'] | undefined,
+  originalFigures: Array<{ type: string; title: string; data: unknown; note: string }> | undefined,
+): Array<{ type: 'data_flow' | 'risk_matrix' | 'utility_chart'; title: string; data: unknown; note: string }> {
+  if (!formFigures) return []
+
+  const result: Array<{
+    type: 'data_flow' | 'risk_matrix' | 'utility_chart'
+    title: string
+    data: unknown
+    note: string
+  }> = []
+
+  formFigures.forEach((fig, index) => {
+    const type = fig.type ?? 'data_flow'
+    const note = fig.note ?? ''
+    const title = fig.title ?? ''
+
+    if (type === 'data_flow') {
+      const rawData = fig.data as
+        | { nodes?: Array<{ id?: string; label?: string; category?: string }>; edges?: unknown[] }
+        | undefined
+      const nodes = (rawData?.nodes ?? [])
+        .filter((n) => (n.label ?? '').trim() !== '')
+        .map((n) => {
+          const cat = (n.category ?? '').trim()
+          const id = (n.id ?? '').trim()
+          return { id, label: (n.label ?? '').trim(), category: cat }
+        })
+
+      if (nodes.length === 0 && title.trim() === '') {
+        return
+      }
+
+      // 空ID をカテゴリに応じて自動採番（既存ID と衝突しないように maxIndex+1）
+      const usedIds = new Set(nodes.filter((n) => n.id !== '').map((n) => n.id))
+      const prefixCounters: Record<string, number> = {}
+      nodes.forEach((node) => {
+        if (node.id !== '') {
+          const match = node.id.match(/^([a-z]+)(\d+)$/)
+          if (match) {
+            const pfx = match[1]
+            const n = parseInt(match[2], 10)
+            prefixCounters[pfx] = Math.max(prefixCounters[pfx] ?? 0, n)
+          }
+        }
+      })
+      nodes.forEach((node) => {
+        if (node.id !== '') return
+        const cat = (DATA_FLOW_NODE_CATEGORIES as readonly string[]).includes(node.category)
+          ? (node.category as DataFlowNodeCategory)
+          : 'source'
+        const prefix = DATA_FLOW_NODE_ID_PREFIX[cat]
+        let next = (prefixCounters[prefix] ?? 0) + 1
+        let candidate = `${prefix}${next}`
+        while (usedIds.has(candidate)) {
+          next += 1
+          candidate = `${prefix}${next}`
+        }
+        node.id = candidate
+        prefixCounters[prefix] = next
+        usedIds.add(candidate)
+      })
+
+      const edges = Array.isArray(rawData?.edges) ? (rawData.edges as unknown[]) : []
+
+      result.push({
+        type: 'data_flow',
+        title: title.trim(),
+        data: { nodes, edges },
+        note,
+      })
+    } else {
+      // risk_matrix / utility_chart: defaultValues 由来の値をそのまま透過保持
+      const original = originalFigures?.[index]
+      result.push({
+        type,
+        title: title.trim(),
+        data: original?.data ?? fig.data,
+        note,
+      })
+    }
+  })
+
+  return result
+}

--- a/src/constants/categories.ts
+++ b/src/constants/categories.ts
@@ -30,6 +30,34 @@ export const TECHNOLOGY_CATEGORY_LABELS: Record<string, string> = {
   distributed_analytics: '分散データ分析',
 }
 
+// data_flow 図のノードカテゴリ。並び順が「source → constraint → process → application → outcome」の流れを表す
+export const DATA_FLOW_NODE_CATEGORIES = [
+  'source',
+  'constraint',
+  'process',
+  'application',
+  'outcome',
+] as const
+
+export type DataFlowNodeCategory = typeof DATA_FLOW_NODE_CATEGORIES[number]
+
+export const DATA_FLOW_NODE_CATEGORY_LABELS: Record<DataFlowNodeCategory, string> = {
+  source: 'source（元データ）',
+  constraint: 'constraint（課題・制約）',
+  process: 'process（PETs手法）',
+  application: 'application（活用先）',
+  outcome: 'outcome（成果）',
+}
+
+// カテゴリ → ノードIDのプレフィックス（既存JSONの命名規則に準拠）
+export const DATA_FLOW_NODE_ID_PREFIX: Record<DataFlowNodeCategory, string> = {
+  source: 's',
+  constraint: 's',
+  process: 'p',
+  application: 'a',
+  outcome: 'a',
+}
+
 export const REVIEW_STATUS_OPTIONS = [
   'ai_generated',
   'human_reviewed',

--- a/src/constants/prompts.ts
+++ b/src/constants/prompts.ts
@@ -165,7 +165,9 @@ ${regionList}
 - 数値があれば盛り込む（例:「有用性97%を達成」「6カ月→3日に短縮」）
 - **constraint ノードの label は「課題と解決」セクションの見出しキーワードとして表示される。課題の核心を端的に表現すること**
 - **outcome ノードの label は「得られた価値」セクションの見出しキーワードとして表示される。成果のハイライトを端的に表現すること**
-- ノードIDは s1, s2（source列）、p1, p2（process列）、a1, a2（application/outcome列）の命名規則
+- **category は以下の5値のみを使用する: \`source\`, \`constraint\`, \`process\`, \`application\`, \`outcome\`**
+- **ノードはカテゴリ順（source → constraint → process → application → outcome）で配列に並べる**
+- ノードIDは s1, s2（source/constraint列）、p1, p2（process列）、a1, a2（application/outcome列）の命名規則
 
 ### 情報が不明な場合
 - 文献から読み取れない項目は「調査中」と記入する（空欄にしない）
@@ -230,6 +232,9 @@ ${currentJson}
 - ノードの追加・分割も、情報が充実した場合は積極的に行ってください
 
 **重要**: constraint / outcome ノードの label は詳細画面の見出しキーワードとしても使われるため、非技術者にも分かりやすい簡潔な表現にしてください
+
+**category は以下の5値のみを使用する**: \`source\`, \`constraint\`, \`process\`, \`application\`, \`outcome\`
+**ノードはカテゴリ順（source → constraint → process → application → outcome）で配列に並べる**
 
 ## 出力形式
 

--- a/src/schemas/case.schema.ts
+++ b/src/schemas/case.schema.ts
@@ -125,6 +125,29 @@ export const caseSchema = z.object({
   updated_at: z.string().min(1),
 });
 
+// Figure schema for form (everything optional; empty entries are filtered/normalized on submit)
+const dataFlowNodeFormSchema = z.object({
+  id: z.string().default(""),
+  label: z.string().default(""),
+  category: z.string().default(""),
+});
+
+const dataFlowDataFormSchema = z.object({
+  nodes: z.array(dataFlowNodeFormSchema).default([]),
+  edges: z.array(dataFlowEdgeSchema).default([]),
+});
+
+export const figureFormSchema = z.object({
+  type: z
+    .enum(["data_flow", "risk_matrix", "utility_chart"])
+    .default("data_flow"),
+  title: z.string().default(""),
+  // フォーム上は data_flow 用の緩いスキーマを使う。非 data_flow 型の data は
+  // CaseForm 側で undefined にし、submit時に defaultValues から透過復元する
+  data: dataFlowDataFormSchema.optional(),
+  note: z.string().default(""),
+});
+
 // Form schema (only source URL is required, everything else optional)
 export const caseFormSchema = z.object({
   title: z.string().default(''),
@@ -143,6 +166,7 @@ export const caseFormSchema = z.object({
   occurred_at: z.string().nullable().optional().default(null),
   tags: z.array(z.string()).default([]),
   sources: z.array(sourceFormSchema).min(1, '出典は最低1件必要です'),
+  figures: z.array(figureFormSchema).default([]),
 })
 
 export type CaseFormData = z.infer<typeof caseFormSchema>


### PR DESCRIPTION
## Summary
- CaseForm に折りたたみの「図表」セクションを追加し、data_flow 図のノード（label / category）を Webフォームから編集可能に
- AIアシストプロンプトに data_flow のカテゴリ順序ルール（source → constraint → process → application → outcome）を明記
- 非エンジニアでも JSON を触らずに data_flow 図を更新可能に

## 実装概要
### 新規ファイル
- \`src/components/case-form/FiguresField.tsx\`
  - \`FiguresField\`: 複数 figure の \`useFieldArray\` 管理
  - \`FigureCard\`: 各 figure のカード（type 表示・タイトル・メモ）
  - \`DataFlowNodesField\`: data_flow 図のノード編集（ラベル + 5択の分類セレクト）
  - \`normalizeFigures\`: submit時のクリーンアップ（空ノード除外、ID自動採番）

### 変更
- \`src/constants/categories.ts\`: \`DATA_FLOW_NODE_CATEGORIES\` / ラベル / IDプレフィックス定数を追加
- \`src/schemas/case.schema.ts\`: \`caseFormSchema\` に \`figures\` 追加、ラベル空を許容する緩い \`figureFormSchema\` 新設
- \`src/components/case-form/CaseForm.tsx\`: 「図表」折りたたみセクション追加、defaultValues/handleSubmit で figures を変換
- \`src/constants/prompts.ts\`: カテゴリ順序ルール・許可カテゴリ5値を generateCreatePrompt / generateEnrichPrompt に明記

## UI 仕様
- 図表セクションはデフォルト折りたたみ（既存の \`CollapsibleSection\` を再利用、「基本情報」「技術情報」「タグ」と統一感）
- 「+ data_flow 図を追加」ボタンで新規figure追加
- 各figureカード:
  - タイトル・メモ入力
  - data_flow: ノード一覧 + 「+ source」「+ constraint」「+ process」「+ application」「+ outcome」ボタン
  - 非 data_flow: 「この図タイプのフォーム編集には現時点で未対応です。値は保持されます」の注記
- 各ノード: ラベル入力 + 分類セレクト（日本語併記: 例 \`source（元データ）\`）。IDは非表示で submit時に自動採番
- 順序の説明文「source → constraint → process → application → outcome」を同セクション内に表示

## スコープ外（必要があれば別Issueで検討）
- \`risk_matrix\` / \`utility_chart\` 図の編集UI（透過保持のみ）
- \`edges\` のフォーム編集UI（透過保持のみ）

## Test plan
- [x] \`npm run test\` 全209件 pass（figures 関連5件、プロンプト関連2件を追加）
- [x] \`npm run build\` 成功
- [x] \`npm run validate\` 全139事例 pass
- [ ] dev サーバで以下を目視確認:
  - [ ] 図表セクションが折りたたまれて表示される
  - [ ] 展開して data_flow を追加 → ノード追加 → ラベル/分類入力 → submit で反映される
  - [ ] 既存事例を編集した際、edges が保持される
  - [ ] risk_matrix / utility_chart を持つ既存事例がある場合、注記表示され値が保持される

Closes #223

🤖 Generated with [Claude Code](https://claude.com/claude-code)